### PR TITLE
Clarified the error message of subData

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -206,7 +206,8 @@ module.exports = function wrapBufferState (gl) {
 
     function setSubData (data, offset) {
       check(offset + data.byteLength <= buffer.byteLength,
-        'invalid buffer subdata call, buffer is too small')
+        'invalid buffer subdata call, buffer is too small. ' + ' Can\'t write data of size ' + data.byteLength + ' starting from offset ' + offset + ' to a buffer of size ' + buffer.byteLength)
+
       gl.bufferSubData(buffer.type, offset, data)
     }
 


### PR DESCRIPTION
The error message generated by subdata() is

```
invalid buffer subdata call, buffer is too small
```

This is too concise and cryptic, and not really useful when you are debugging. I made this message more descriptive, so that it looks more like

```
invalid buffer subdata call, buffer is too small.  Can't write data of size 1452 starting from offset 0 to a buffer of size 1442
```

