### PR TITLE
Validation fixes

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -3,6 +3,7 @@ var createEnvironment = require('./util/codegen')
 var loop = require('./util/loop')
 var isTypedArray = require('./util/is-typed-array')
 var isNDArray = require('./util/is-ndarray')
+var isArrayLike = require('./util/is-array-like')
 
 var primTypes = require('./constants/primitives.json')
 var glTypes = require('./constants/dtypes.json')
@@ -392,6 +393,10 @@ module.exports = function reglCore (
     glTypes: glTypes,
     orientationType: orientationType
   }
+
+  check.optional(function () {
+    sharedState.isArrayLike = isArrayLike
+  })
 
   if (extDrawBuffers) {
     sharedConstants.backBuffer = [GL_BACK]
@@ -1081,7 +1086,7 @@ module.exports = function reglCore (
           return parseParam(
             function (value) {
               check.command(
-                Array.isArray(value) &&
+                isArrayLike(value) &&
                 value.length === 2 &&
                 typeof value[0] === 'number' &&
                 typeof value[1] === 'number' &&
@@ -1092,7 +1097,7 @@ module.exports = function reglCore (
             function (env, scope, value) {
               check.optional(function () {
                 env.assert(scope,
-                  'Array.isArray(' + value + ')&&' +
+                  env.shared.isArrayLike + '(' + value + ')&&' +
                   value + '.length===2&&' +
                   'typeof ' + value + '[0]==="number"&&' +
                   'typeof ' + value + '[1]==="number"&&' +
@@ -1216,7 +1221,7 @@ module.exports = function reglCore (
           return parseParam(
             function (value) {
               check.command(
-                Array.isArray(value) &&
+                isArrayLike(value) &&
                 value.length === 4,
                 'blend.color must be a 4d array')
               return loop(4, function (i) {
@@ -1226,7 +1231,7 @@ module.exports = function reglCore (
             function (env, scope, value) {
               check.optional(function () {
                 env.assert(scope,
-                  'Array.isArray(' + value + ')&&' +
+                  env.shared.isArrayLike + '(' + value + ')&&' +
                   value + '.length===4',
                   'blend.color must be a 4d array')
               })
@@ -1426,14 +1431,14 @@ module.exports = function reglCore (
           return parseParam(
             function (value) {
               check.command(
-                Array.isArray(value) && value.length === 4,
+                isArrayLike(value) && value.length === 4,
                 'color.mask must be length 4 array')
               return value.map(function (v) { return !!v })
             },
             function (env, scope, value) {
               check.optional(function () {
                 env.assert(scope,
-                  'Array.isArray(' + value + ')&&' +
+                  env.shared.isArrayLike + '(' + value + ')&&' +
                   value + '.length===4',
                   'invalid color.mask')
               })
@@ -1549,7 +1554,7 @@ module.exports = function reglCore (
         result = createStaticDecl(function (env) {
           return env.link(value)
         })
-      } else if (Array.isArray(value) || isTypedArray(value)) {
+      } else if (isArrayLike(value)) {
         result = createStaticDecl(function (env) {
           var ITEM = env.global.def('[',
             loop(value.length, function (i) {
@@ -1610,7 +1615,7 @@ module.exports = function reglCore (
               record.x = constant
             } else {
               check.command(
-                Array.isArray(constant) &&
+                isArrayLike(constant) &&
                 constant.length > 0 &&
                 constant.length <= 4,
                 'invalid constant for attribute ' + attribute)
@@ -1727,7 +1732,7 @@ module.exports = function reglCore (
             BUFFER_STATE + '.getBuffer(' + VALUE + '.buffer)||' +
             '("constant" in ' + VALUE +
             '&&(typeof ' + VALUE + '.constant==="number"||' +
-            'Array.isArray(' + VALUE + '))))',
+            shared.isArrayLike + '(' + VALUE + '))))',
             'invalid dynamic attribute "' + attribute + '"')
         })
 
@@ -1966,7 +1971,7 @@ module.exports = function reglCore (
             .else(GL, '.disable(', flag, ');'))
         }
         scope(CURRENT_STATE, '.', param, '=', variable, ';')
-      } else if (Array.isArray(variable)) {
+      } else if (isArrayLike(variable)) {
         var CURRENT = CURRENT_VARS[param]
         scope(
           GL, '.', GL_VARIABLES[param], '(', variable, ');',
@@ -2172,7 +2177,7 @@ module.exports = function reglCore (
             type === GL_FLOAT_MAT3 ||
             type === GL_FLOAT_MAT4) {
             check.optional(function () {
-              check.command(isTypedArray(value) || Array.isArray(value),
+              check.command(isArrayLike(value),
                 'invalid matrix for uniform ' + name)
               check.command(
                 (type === GL_FLOAT_MAT2 && value.length === 4) ||
@@ -2198,7 +2203,7 @@ module.exports = function reglCore (
                 break
               case GL_FLOAT_VEC2:
                 check.command(
-                  (Array.isArray(value) || isTypedArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 2 &&
                   typeof value[0] === 'number' &&
                   typeof value[1] === 'number',
@@ -2207,7 +2212,7 @@ module.exports = function reglCore (
                 break
               case GL_FLOAT_VEC3:
                 check.command(
-                  (Array.isArray(value) || isTypedArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 3 &&
                   typeof value[0] === 'number' &&
                   typeof value[1] === 'number' &&
@@ -2217,7 +2222,7 @@ module.exports = function reglCore (
                 break
               case GL_FLOAT_VEC4:
                 check.command(
-                  (Array.isArray(value) || isTypedArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 4 &&
                   typeof value[0] === 'number' &&
                   typeof value[1] === 'number' &&
@@ -2238,7 +2243,7 @@ module.exports = function reglCore (
                 break
               case GL_BOOL_VEC2:
                 check.command(
-                  (Array.isArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 2 &&
                   typeof value[0] === 'boolean' &&
                   typeof value[1] === 'boolean',
@@ -2247,7 +2252,7 @@ module.exports = function reglCore (
                 break
               case GL_INT_VEC2:
                 check.command(
-                  (Array.isArray(value) || isTypedArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 2 &&
                   typeof value[0] === 'number' && value[0] === (value[0] | 0) &&
                   typeof value[1] === 'number' && value[1] === (value[1] | 0),
@@ -2256,7 +2261,7 @@ module.exports = function reglCore (
                 break
               case GL_BOOL_VEC3:
                 check.command(
-                  (Array.isArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 3 &&
                   typeof value[0] === 'boolean' &&
                   typeof value[1] === 'boolean' &&
@@ -2266,7 +2271,7 @@ module.exports = function reglCore (
                 break
               case GL_INT_VEC3:
                 check.command(
-                  (Array.isArray(value) || isTypedArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 3 &&
                   typeof value[0] === 'number' && value[0] === (value[0] | 0) &&
                   typeof value[1] === 'number' && value[1] === (value[1] | 0) &&
@@ -2276,7 +2281,7 @@ module.exports = function reglCore (
                 break
               case GL_BOOL_VEC4:
                 check.command(
-                  (Array.isArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 4 &&
                   typeof value[0] === 'boolean' &&
                   typeof value[1] === 'boolean' &&
@@ -2287,7 +2292,7 @@ module.exports = function reglCore (
                 break
               case GL_INT_VEC4:
                 check.command(
-                  (Array.isArray(value) || isTypedArray(value)) &&
+                  isArrayLike(value) &&
                   value.length === 4 &&
                   typeof value[0] === 'number' && value[0] === (value[0] | 0) &&
                   typeof value[1] === 'number' && value[1] === (value[1] | 0) &&
@@ -2323,7 +2328,7 @@ module.exports = function reglCore (
         }
 
         function checkVector (n, type) {
-          check('Array.isArray(' + VALUE + ')&&' + VALUE + '.length===' + n)
+          check(shared.isArrayLike + '(' + VALUE + ')&&' + VALUE + '.length===' + n)
         }
 
         function checkTexture (target) {
@@ -2869,7 +2874,7 @@ module.exports = function reglCore (
     sortState(Object.keys(args.state)).forEach(function (name) {
       var defn = args.state[name]
       var value = defn.append(env, scope)
-      if (Array.isArray(value)) {
+      if (isArrayLike(value)) {
         value.forEach(function (v, i) {
           scope.set(env.next[name], '[' + i + ']', v)
         })
@@ -2986,7 +2991,7 @@ module.exports = function reglCore (
         var NEXT, CURRENT
         var block = env.block()
         block(GL, '.', func, '(')
-        if (Array.isArray(init)) {
+        if (isArrayLike(init)) {
           var n = init.length
           NEXT = env.global.def(NEXT_STATE, '.', name)
           CURRENT = env.global.def(CURRENT_STATE, '.', name)

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -7,7 +7,6 @@ var GL_FRAMEBUFFER = 0x8D40
 var GL_RENDERBUFFER = 0x8D41
 
 var GL_TEXTURE_2D = 0x0DE1
-var GL_TEXTURE_CUBE_MAP = 0x8513
 var GL_TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515
 
 var GL_COLOR_ATTACHMENT0 = 0x8CE0
@@ -152,14 +151,12 @@ module.exports = function wrapFBOState (
     var height = framebuffer.height
     if (attachment.texture) {
       var texture = attachment.texture._texture
-      var tw = Math.max(1, texture.params.width >> attachment.level)
-      var th = Math.max(1, texture.params.height >> attachment.level)
+      var tw = Math.max(1, texture.width >> attachment.level)
+      var th = Math.max(1, texture.height >> attachment.level)
       width = width || tw
       height = height || th
       check(tw === width && th === height,
         'inconsistent width/height for supplied texture')
-      check(texture.pollId < 0,
-        'polling fbo textures not supported')
       texture.refCount += 1
     } else {
       var renderbuffer = attachment.renderbuffer._renderbuffer
@@ -258,17 +255,16 @@ module.exports = function wrapFBOState (
     check.type(data, 'function', 'invalid attachment data')
 
     var type = attachment._reglType
-    if (type === 'texture') {
+    if (type === 'texture2d') {
+      // TODO check miplevel
       texture = attachment
-      if (texture._texture.target === GL_TEXTURE_CUBE_MAP) {
-        check(
-          target >= GL_TEXTURE_CUBE_MAP_POSITIVE_X &&
-          target < GL_TEXTURE_CUBE_MAP_POSITIVE_X + 6,
-          'invalid cube map target')
-      } else {
-        check(target === GL_TEXTURE_2D)
-      }
-      // TODO check miplevel is consistent
+      check(target === GL_TEXTURE_2D)
+    } else if (type === 'textureCube') {
+      texture = attachment
+      check(
+        target >= GL_TEXTURE_CUBE_MAP_POSITIVE_X &&
+        target < GL_TEXTURE_CUBE_MAP_POSITIVE_X + 6,
+        'invalid cube map target')
     } else if (type === 'renderbuffer') {
       renderbuffer = attachment
       target = GL_RENDERBUFFER

--- a/lib/texture.js
+++ b/lib/texture.js
@@ -717,7 +717,7 @@ module.exports = function createTextureSet (
     }
 
     if (image.type === GL_FLOAT) {
-      check(limits.extenstions.indexOf('oes_texture_float') >= 0,
+      check(limits.extensions.indexOf('oes_texture_float') >= 0,
         'oes_texture_float extension not enabled')
     } else if (image.type === GL_HALF_FLOAT_OES) {
       check(limits.extensions.indexOf('oes_texture_half_float') >= 0,

--- a/lib/texture.js
+++ b/lib/texture.js
@@ -5,6 +5,7 @@ var isTypedArray = require('./util/is-typed-array')
 var isNDArrayLike = require('./util/is-ndarray')
 var pool = require('./util/pool')
 var convertToHalfFloat = require('./util/to-half-float')
+var isArrayLike = require('./util/is-array-like')
 
 var dtypes = require('./constants/arraytypes.json')
 var arrayTypes = require('./constants/arraytypes.json')
@@ -152,15 +153,8 @@ function isRectArray (arr) {
   }
 
   var width = arr.length
-  if (width === 0 || !Array.isArray(arr[0])) {
+  if (width === 0 || !isArrayLike(arr[0])) {
     return false
-  }
-
-  var height = arr[0].length
-  for (var i = 1; i < width; ++i) {
-    if (!Array.isArray(arr[i]) || arr[i].length !== height) {
-      return false
-    }
   }
   return true
 }
@@ -702,7 +696,7 @@ module.exports = function createTextureSet (
       var w = data[0].length
       var h = data.length
       var c = 1
-      if (Array.isArray(data[0][0])) {
+      if (isArrayLike(data[0][0])) {
         c = data[0][0].length
         flatten3DData(image, data, w, h, c)
       } else {

--- a/lib/texture.js
+++ b/lib/texture.js
@@ -151,7 +151,6 @@ function isRectArray (arr) {
   if (!Array.isArray(arr)) {
     return false
   }
-
   var width = arr.length
   if (width === 0 || !isArrayLike(arr[0])) {
     return false
@@ -1003,6 +1002,7 @@ module.exports = function createTextureSet (
   function REGLTexture (target) {
     TexFlags.call(this)
     this.mipmask = 0
+    this.internalformat = GL_RGBA
 
     this.id = textureCount++
 
@@ -1117,6 +1117,7 @@ module.exports = function createTextureSet (
       copyFlags(texture, mipData)
 
       check.texture2D(texInfo, mipData, limits)
+      texture.internalformat = mipData.internalformat
 
       reglTexture2D.width = mipData.width
       reglTexture2D.height = mipData.height
@@ -1242,6 +1243,7 @@ module.exports = function createTextureSet (
       }
 
       check.textureCube(texture, texInfo, faces, limits)
+      texture.internalformat = faces[0].internalformat
 
       reglTextureCube.width = faces[0].width
       reglTextureCube.height = faces[0].height

--- a/lib/util/check.js
+++ b/lib/util/check.js
@@ -372,7 +372,7 @@ function checkOptional (block) {
 function checkFramebufferFormat (attachment, texFormats, rbFormats) {
   if (attachment.texture) {
     checkOneOf(
-      attachment.texture._texture.params.internalformat,
+      attachment.texture._texture.internalformat,
       texFormats,
       'unsupported texture format for attachment')
   } else {

--- a/lib/util/is-array-like.js
+++ b/lib/util/is-array-like.js
@@ -1,0 +1,4 @@
+var isTypedArray = require('./is-typed-array')
+module.exports = function isArrayLike (s) {
+  return Array.isArray(s) || isTypedArray(s)
+}


### PR DESCRIPTION
This PR fixes a bunch of validation issues caused by changes to the texture API and uniform validation introduced in 0.8.0.  It should triage the following issues:

* https://github.com/mikolalysenko/regl/issues/28
* https://github.com/mikolalysenko/regl/issues/30

There are 3 things that it adds:

1. It fixes a typo with float texture construction
2. Instead of checking if an input is an array using `Array.isArray`, for flat arrays we now use the new function `isArrayLike()` that also tests if the array is a typed array.  This is now applied to uniforms and in several other places in the validation logic.
3. There were a few bugs in the frame buffer logic caused by changes in the textures that were solved.