### PR TITLE
Use poll() instead of refresh() in raf handler

### DIFF
--- a/regl.js
+++ b/regl.js
@@ -132,6 +132,9 @@ module.exports = function wrapREGL () {
       var cb = rafCallbacks[i]
       cb(contextState, null, 0)
     }
+
+    // flush all pending webgl calls
+    gl.flush()
   }
 
   function startRAF () {


### PR DESCRIPTION
This PR fixes a small logical error in the RAF handler.  Previously it was resetting all WebGL state which isn't necessary.  Also, the RAF loop now calls `gl.flush()` once all commands have completed.