### PR TITLE
Remove deltaTime

### DIFF
--- a/API.md
+++ b/API.md
@@ -297,7 +297,6 @@ Context variables in `regl` are computed before any other parameters and can als
 | Name | Description |
 |------|-------------|
 | `frameCount` | The number of frames rendered |
-| `deltaTime` | Time since the last frame was rendered in seconds |
 | `time` | Total time elapsed since the regl was initialized in seconds |
 | `viewportWidth` | Width of the current viewport in pixels |
 | `viewportHeight` | Height of the current viewport in pixels |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
 
 ## Next
 
+* Remove `deltaTime` context variable
 * Uniform validation fixes
 * Texture construction fixes
 * Improved test coverage for uniform variables

--- a/example/cloth.js
+++ b/example/cloth.js
@@ -215,7 +215,9 @@ require('resl')({
   },
 
   onDone: ({ clothTexture }) => {
-    regl.frame(({deltaTime, count}) => {
+    regl.frame(({count}) => {
+      const deltaTime = 0.017
+
       regl.clear({
         color: [0, 0, 0, 255],
         depth: 1

--- a/regl.js
+++ b/regl.js
@@ -41,13 +41,11 @@ module.exports = function wrapREGL () {
   var extensions = extensionState.extensions
 
   var START_TIME = clock()
-  var LAST_TIME = START_TIME
   var WIDTH = gl.drawingBufferWidth
   var HEIGHT = gl.drawingBufferHeight
 
   var contextState = {
     count: 0,
-    deltaTime: 0,
     time: 0,
     viewportWidth: WIDTH,
     viewportHeight: HEIGHT,
@@ -118,10 +116,8 @@ module.exports = function wrapREGL () {
     // increment frame count
     contextState.count += 1
 
-    var now = clock()
-    contextState.deltaTime = (now - LAST_TIME) / 1000.0
-    contextState.time = (now - START_TIME) / 1000.0
-    LAST_TIME = now
+    // Update time
+    contextState.time = (clock() - START_TIME) / 1000.0
 
     refresh()
 


### PR DESCRIPTION
This PR removes the deltaTime context variable.  deltaTime encourages error prone code like using a variable time step for simulations or games.