### PR TITLE
Fixed bug with draw properties incorrectly lowering in batch mode

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2449,7 +2449,7 @@ module.exports = function reglCore (
       var ELEMENTS
       var scope = outer
       if (defn) {
-        if (!defn.batchStatic) {
+        if ((defn.contextDep && args.contextDynamic) || defn.propDep) {
           scope = inner
         }
         ELEMENTS = defn.append(env, scope)
@@ -2469,7 +2469,7 @@ module.exports = function reglCore (
       var COUNT
       var scope = outer
       if (defn) {
-        if (!defn.batchStatic) {
+        if ((defn.contextDep && args.contextDynamic) || defn.propDep) {
           scope = inner
         }
         COUNT = defn.append(env, scope)
@@ -2491,10 +2491,10 @@ module.exports = function reglCore (
     function emitValue (name) {
       var defn = drawOptions[name]
       if (defn) {
-        if (defn.batchStatic) {
-          return defn.append(env, outer)
-        } else {
+        if ((defn.contextDep && args.contextDynamic) || defn.propDep) {
           return defn.append(env, inner)
+        } else {
+          return defn.append(env, outer)
         }
       } else {
         return outer.def(DRAW_STATE, '.', name)


### PR DESCRIPTION
Found this when investigating the test coverage results.  The problem was caused by some legacy cruft not getting correctly updated during the big refactor in 0.7.0.