### PR TITLE
Track and destroy element buffers separately

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -62,6 +62,10 @@ module.exports = function wrapBufferState (gl) {
     gl.bindBuffer(this.type, this.buffer)
   }
 
+  REGLBuffer.prototype.destroy = function () {
+    destroy(this)
+  }
+
   var streamPool = []
 
   function createStream (type, data) {

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -1,6 +1,7 @@
 var check = require('./util/check')
 var isTypedArray = require('./util/is-typed-array')
 var isNDArrayLike = require('./util/is-ndarray')
+var values = require('./util/values')
 
 var primTypes = require('./constants/primitives.json')
 var usageTypes = require('./constants/usage.json')
@@ -22,6 +23,9 @@ var GL_STREAM_DRAW = 0x88E0
 var GL_STATIC_DRAW = 0x88E4
 
 module.exports = function wrapElementsState (gl, extensions, bufferState) {
+  var elementSet = {}
+  var elementCount = 0
+
   var elementTypes = {
     'uint8': GL_UNSIGNED_BYTE,
     'uint16': GL_UNSIGNED_SHORT
@@ -32,6 +36,8 @@ module.exports = function wrapElementsState (gl, extensions, bufferState) {
   }
 
   function REGLElementBuffer (buffer) {
+    this.id = elementCount++
+    elementSet[this.id] = this
     this.buffer = buffer
     this.primType = GL_TRIANGLES
     this.vertCount = 0
@@ -139,6 +145,13 @@ module.exports = function wrapElementsState (gl, extensions, bufferState) {
     elements.primType = primType
   }
 
+  function destroyElements (elements) {
+    check(elements.buffer !== null, 'must not double destroy elements')
+    delete elementSet[elements.id]
+    elements.buffer.destroy()
+    elements.buffer = null
+  }
+
   function createElements (options) {
     var buffer = bufferState.create(null, GL_ELEMENT_ARRAY_BUFFER, true)
     var elements = new REGLElementBuffer(buffer._buffer)
@@ -241,9 +254,7 @@ module.exports = function wrapElementsState (gl, extensions, bufferState) {
       return reglElements
     }
     reglElements.destroy = function () {
-      check(elements.buffer !== null, 'must not double destroy elements')
-      buffer.destroy()
-      elements.buffer = null
+      destroyElements(elements)
     }
 
     return reglElements
@@ -259,6 +270,9 @@ module.exports = function wrapElementsState (gl, extensions, bufferState) {
         return elements._elements
       }
       return null
+    },
+    clear: function () {
+      values(elementSet).forEach(destroyElements)
     }
   }
 }

--- a/regl.js
+++ b/regl.js
@@ -170,6 +170,7 @@ module.exports = function wrapREGL () {
     framebufferState.clear()
     renderbufferState.clear()
     textureState.clear()
+    elementState.clear()
     bufferState.clear()
 
     if (options.onDestroy) {


### PR DESCRIPTION
This PR implements separate resource tracking for element buffers.  This solves #40 and is necessary for the last test cases in #41 to pass.