### PR TITLE
Refactor renderbuffers

### DIFF
--- a/API.md
+++ b/API.md
@@ -1691,6 +1691,8 @@ var rgba_16x24 = regl.renderbuffer(16, 24)
 | `'format'` | Sets the internal format of the render buffer (see below) | `'rgba4'` |
 | `'width'` | Sets the width of the render buffer in pixels | `1` |
 | `'height'` | Sets the height of the render buffer in pixels | `1` |
+| `'shape'` | Alias for width and height | `[1,1]` |
+| `'radius'` | Simultaneously sets width and height | `1` |
 
 | Format | Description |
 |--------|-------------|
@@ -1715,9 +1717,25 @@ var rgba_16x24 = regl.renderbuffer(16, 24)
 Like all other resources, renderbuffers can be updated in place:
 
 ```javascript
+var renderbuffer = regl.renderbuffer()
+
+renderbuffer({
+  radius: 3,
+  format: 'depth'
+})
 ```
 
 ##### Resizing
+A renderbuffer can also be resized in place by calling `.resize()`:
+
+```javascript
+var renderbuffer = regl.renderbuffer({
+  shape: [10, 10],
+  format: 'depth stencil'
+})
+
+renderbuffer.resize(32, 32)
+```
 
 #### Destroy
 

--- a/API.md
+++ b/API.md
@@ -1675,16 +1675,20 @@ cubeMap.destroy()
 
 #### Constructor
 ```javascript
+// Allocate a new renderbuffer with the prescribed format
 var rb = regl.renderbuffer({
   width: 16,
   height: 16,
   format: 'rgba4'
 })
+
+// Allocate an 'rgba4' renderbuffer with a fixed size
+var rgba_16x24 = regl.renderbuffer(16, 24)
 ```
 
 | Property | Interpretation | Default |
 |----------|----------------|---------|
-| `'format'` | Sets the internal format of the render buffer | `'rgba4'` |
+| `'format'` | Sets the internal format of the render buffer (see below) | `'rgba4'` |
 | `'width'` | Sets the width of the render buffer in pixels | `1` |
 | `'height'` | Sets the height of the render buffer in pixels | `1` |
 
@@ -1696,6 +1700,9 @@ var rb = regl.renderbuffer({
 | `'depth'` | `gl.DEPTH_COMPONENT16` |
 | `'stencil'` | `gl.STENCIL_INDEX8` |
 | `'srgba'` | `ext.SRGB8_ALPHA8_EXT`, only if [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) supported |
+| `'rgba16f'` | 16 bit floating point RGBA buffer, only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/) |
+| `'rgb16f'` | 16 bit floating point RGB buffer, only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/) |
+| `'rgba32f'` | 32 bit floating point RGBA buffer, only if [WEBGL_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/) supported |
 
 **Relevant WebGL APIs**
 
@@ -1705,8 +1712,12 @@ var rb = regl.renderbuffer({
 * [`gl.bindRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindRenderbuffer.xml)
 
 #### Update
+Like all other resources, renderbuffers can be updated in place:
 
-**TODO**
+```javascript
+```
+
+##### Resizing
 
 #### Destroy
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Planned
 
-* Optimize constructors/updates for renderbuffers and framebuffers
+* Optimize constructors/updates for framebuffers
 * Cubic frame buffer objects
 * More test cases for framebuffers
 
@@ -48,6 +48,8 @@
 
 ## Next
 
+* Clean up renderbuffer constructor and improve test coverage
+* Added `resize` method to renderbuffers
 * Added performance monitoring hooks via `regl.stats`
 * Rename `count` context variable to `tick`
 * Remove `deltaTime` context variable

--- a/lib/renderbuffer.js
+++ b/lib/renderbuffer.js
@@ -43,11 +43,11 @@ module.exports = function (gl, extensions, limits, stats) {
   var renderbufferCount = 0
   var renderbufferSet = {}
 
-  function REGLRenderbuffer () {
+  function REGLRenderbuffer (renderbuffer) {
     this.id = renderbufferCount++
     this.refCount = 1
 
-    this.renderbuffer = null
+    this.renderbuffer = renderbuffer
 
     this.format = GL_RGBA4
     this.width = 0
@@ -60,80 +60,113 @@ module.exports = function (gl, extensions, limits, stats) {
     }
   }
 
-  function refresh (rb) {
-    if (!gl.isRenderbuffer(rb.renderbuffer)) {
-      rb.renderbuffer = gl.createRenderbuffer()
-    }
-    gl.bindRenderbuffer(GL_RENDERBUFFER, rb.renderbuffer)
-    gl.renderbufferStorage(
-      GL_RENDERBUFFER,
-      rb.format,
-      rb.width,
-      rb.height)
-  }
-
   function destroy (rb) {
-    stats.renderbufferCount--
-
     var handle = rb.renderbuffer
     check(handle, 'must not double destroy renderbuffer')
     gl.bindRenderbuffer(GL_RENDERBUFFER, null)
-    if (gl.isRenderbuffer(handle)) {
-      gl.deleteRenderbuffer(handle)
-    }
+    gl.deleteRenderbuffer(handle)
     rb.renderbuffer = null
     rb.refCount = 0
     delete renderbufferSet[rb.id]
+    stats.renderbufferCount--
   }
 
-  function createRenderbuffer (input) {
-    var renderbuffer = new REGLRenderbuffer()
+  function createRenderbuffer (a, b) {
+    var renderbuffer = new REGLRenderbuffer(gl.createRenderbuffer())
     renderbufferSet[renderbuffer.id] = renderbuffer
 
-    function reglRenderbuffer (input) {
+    function reglRenderbuffer (a, b) {
       stats.renderbufferCount++
-
-      var options = input || {}
 
       var w = 0
       var h = 0
-      if ('shape' in options) {
-        var shape = options.shape
-        check(Array.isArray(shape) && shape.length >= 2,
-          'invalid renderbuffer shape')
-        w = shape[0] | 0
-        h = shape[1] | 0
+      var format = GL_RGBA4
+
+      if (typeof a === 'object' && a) {
+        var options = a
+        if ('shape' in options) {
+          var shape = options.shape
+          check(Array.isArray(shape) && shape.length >= 2,
+            'invalid renderbuffer shape')
+          w = shape[0] | 0
+          h = shape[1] | 0
+        } else {
+          if ('radius' in options) {
+            w = h = options.radius | 0
+          }
+          if ('width' in options) {
+            w = options.width | 0
+          }
+          if ('height' in options) {
+            h = options.height | 0
+          }
+        }
+        if ('format' in options) {
+          check.parameter(options.format, formatTypes,
+            'invalid renderbuffer format')
+          format = formatTypes[options.format]
+        }
+      } else if (typeof a === 'number') {
+        w = a | 0
+        if (typeof b === 'number') {
+          h = b | 0
+        } else {
+          w = h
+        }
+      } else if (!a) {
+        w = h = 1
       } else {
-        if ('radius' in options) {
-          w = h = options.radius | 0
-        }
-        if ('width' in options) {
-          w = options.width | 0
-        }
-        if ('height' in options) {
-          h = options.height | 0
-        }
+        check.raise('invalid arguments to renderbuffer constructor')
       }
-      var s = limits.maxRenderbufferSize
-      check(w >= 0 && h >= 0 && w <= s && h <= s,
+
+      // check shape
+      check(
+        w > 0 && h > 0 &&
+        w <= limits.maxRenderbufferSize && h <= limits.maxRenderbufferSize,
         'invalid renderbuffer size')
-      reglRenderbuffer.width = renderbuffer.width = Math.max(w, 1)
-      reglRenderbuffer.height = renderbuffer.height = Math.max(h, 1)
 
-      renderbuffer.format = GL_RGBA4
-      if ('format' in options) {
-        var format = options.format
-        check.parameter(format, formatTypes, 'invalid render buffer format')
-        renderbuffer.format = formatTypes[format]
+      if (w === renderbuffer.width &&
+          h === renderbuffer.height &&
+          format === renderbuffer.format) {
+        return
       }
 
-      refresh(renderbuffer)
+      reglRenderbuffer.width = renderbuffer.width = w
+      reglRenderbuffer.height = renderbuffer.height = h
+      renderbuffer.format = format
+
+      gl.bindRenderbuffer(GL_RENDERBUFFER, renderbuffer.renderbuffer)
+      gl.renderbufferStorage(GL_RENDERBUFFER, format, w, h)
 
       return reglRenderbuffer
     }
 
-    reglRenderbuffer(input)
+    reglRenderbuffer(a, b)
 
+    function resize (w_, h_) {
+      var w = w_ | 0
+      var h = (h_ | 0) || w
+
+      if (w === renderbuffer.width && h === renderbuffer.height) {
+        return
+      }
+
+      // check shape
+      check(
+        w > 0 && h > 0 &&
+        w <= limits.maxRenderbufferSize && h <= limits.maxRenderbufferSize,
+        'invalid renderbuffer size')
+
+      reglRenderbuffer.width = renderbuffer.width = w
+      reglRenderbuffer.height = renderbuffer.height = h
+
+      gl.bindRenderbuffer(GL_RENDERBUFFER, renderbuffer.renderbuffer)
+      gl.renderbufferStorage(GL_RENDERBUFFER, renderbuffer.format, w, h)
+
+      return reglRenderbuffer
+    }
+
+    reglRenderbuffer.resize = resize
     reglRenderbuffer._reglType = 'renderbuffer'
     reglRenderbuffer._renderbuffer = renderbuffer
     reglRenderbuffer.destroy = function () {
@@ -143,17 +176,10 @@ module.exports = function (gl, extensions, limits, stats) {
     return reglRenderbuffer
   }
 
-  function refreshRenderbuffers () {
-    values(renderbufferSet).forEach(refresh)
-  }
-
-  function destroyRenderbuffers () {
-    values(renderbufferSet).forEach(destroy)
-  }
-
   return {
     create: createRenderbuffer,
-    refresh: refreshRenderbuffers,
-    clear: destroyRenderbuffers
+    clear: function () {
+      values(renderbufferSet).forEach(destroy)
+    }
   }
 }

--- a/test/renderbuffer.js
+++ b/test/renderbuffer.js
@@ -6,7 +6,8 @@ tape('renderbuffer parsing', function (t) {
   var gl = createContext(16, 16)
   var regl = createREGL(gl)
 
-  function checkProperties (renderbuffer, props, prefix) {
+  function checkProperties (prefix, renderbuffer, props) {
+    t.equals(gl.getError(), 0, prefix + ' no gl error')
     t.equals(renderbuffer._reglType, 'renderbuffer', prefix + ' regltype ok')
 
     var rbProps = renderbuffer._renderbuffer
@@ -17,18 +18,165 @@ tape('renderbuffer parsing', function (t) {
 
     gl.bindRenderbuffer(gl.RENDERBUFFER, rbProps.renderbuffer)
     t.equals(gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_WIDTH), props.width, prefix + ' rb width')
-    t.equals(gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_HEIGHT), props.width, prefix + ' rb height')
+    t.equals(gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_HEIGHT), props.height, prefix + ' rb height')
     t.equals(gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_INTERNAL_FORMAT), props.format, prefix + ' rb format')
   }
 
-  checkProperties(
-    regl.renderbuffer(),
-    {
+  function checkThrows (name, props) {
+    t.throws(function () {
+      regl.renderbuffer(props)
+    }, /\(regl\)/, name)
+  }
+
+  checkProperties('empty',
+    regl.renderbuffer(), {
       width: 1,
       height: 1,
       format: gl.RGBA4
-    },
-    'empty')
+    })
+
+  checkProperties('width/height',
+    regl.renderbuffer(5, 7), {
+      width: 5,
+      height: 7,
+      format: gl.RGBA4
+    })
+
+  checkThrows('negative width', {
+    width: -1
+  })
+
+  checkThrows('huge shape', {
+    radius: 1e9
+  })
+
+  checkThrows('bad format', {
+    radius: 10,
+    format: 'bad format'
+  })
+
+  checkProperties('rgb565',
+    regl.renderbuffer({
+      shape: [2, 3],
+      format: 'rgb565'
+    }), {
+      width: 2,
+      height: 3,
+      format: gl.RGB565
+    })
+
+  checkProperties('rgb5 a1',
+    regl.renderbuffer({
+      radius: 3,
+      format: 'rgb5 a1'
+    }), {
+      width: 3,
+      height: 3,
+      format: gl.RGB5_A1
+    })
+
+  checkProperties('depth',
+    regl.renderbuffer({
+      radius: 1,
+      format: 'depth'
+    }), {
+      width: 1,
+      height: 1,
+      format: gl.DEPTH_COMPONENT16
+    })
+
+  checkProperties('stencil',
+    regl.renderbuffer({
+      width: 2,
+      height: 3,
+      format: 'stencil'
+    }), {
+      width: 2,
+      height: 3,
+      format: gl.STENCIL_INDEX8
+    })
+
+  checkProperties('depth stencil',
+    regl.renderbuffer({
+      width: 5,
+      height: 5,
+      format: 'depth stencil'
+    }), {
+      width: 5,
+      height: 5,
+      format: gl.DEPTH_STENCIL
+    })
+
+  // try resizing
+  var depthBuffer = regl.renderbuffer({
+    radius: 3,
+    format: 'depth'
+  })
+
+  checkProperties('depth - init', depthBuffer, {
+    width: 3,
+    height: 3,
+    format: gl.DEPTH_COMPONENT16
+  })
+
+  depthBuffer.resize(8, 10)
+  checkProperties('depth resize', depthBuffer, {
+    width: 8,
+    height: 10,
+    format: gl.DEPTH_COMPONENT16
+  })
+
+  checkProperties('reinit', depthBuffer({
+    radius: 3,
+    format: 'rgba4'
+  }), {
+    width: 3,
+    height: 3,
+    format: gl.RGBA4
+  })
+
+  // check extensions
+  if (regl.hasExtension('ext_srgb')) {
+    checkProperties('srgba', regl.renderbuffer({
+      radius: 1,
+      format: 'srgba'
+    }), {
+      width: 1,
+      height: 1,
+      format: gl.getExtension('ext_srgb').SRGB8_ALPHA8_EXT
+    })
+  }
+
+  if (regl.hasExtension('ext_color_buffer_half_float')) {
+    var ext = gl.getExtension('ext_color_buffer_half_float')
+    checkProperties('rgba16f', regl.renderbuffer({
+      radius: 1,
+      format: 'rgba16f'
+    }), {
+      width: 1,
+      height: 1,
+      format: ext.RGBA16F_EXT
+    })
+    checkProperties('rgb16f', regl.renderbuffer({
+      radius: 1,
+      format: 'rgb16f'
+    }), {
+      width: 1,
+      height: 1,
+      format: ext.RGB16F_EXT
+    })
+  }
+
+  if (regl.hasExtension('webgl_color_buffer_float')) {
+    checkProperties('rgba16f', regl.renderbuffer({
+      radius: 1,
+      format: 'rgba32f'
+    }), {
+      width: 1,
+      height: 1,
+      format: gl.getExtension('webgl_color_buffer_float').RGBA32F_EXT
+    })
+  }
 
   regl.destroy()
   createContext.destroy(gl)


### PR DESCRIPTION
This PR refactors the render buffer resource type, paving the way for improvements to the frame buffer constructor.  It also adds a `resize()` method to renderbuffers so they can be quickly resized in place.