### PR TITLE
Add `regl.updateTimer()` call to examples.

### DIFF
--- a/example/audio.js
+++ b/example/audio.js
@@ -173,6 +173,8 @@ require('resl')({
     }
     const freqSamples = new Uint8Array(N)
     regl.frame(({frameCount}) => {
+      regl.updateTimer()
+
       const offsetRow = frameCount % N
 
       // Clear background

--- a/example/batch.js
+++ b/example/batch.js
@@ -54,6 +54,8 @@ const draw = regl({
 
 // Here we register a per-frame callback to draw the whole scene
 regl.frame(function () {
+  regl.updateTimer()
+
   regl.clear({
     color: [0, 0, 0, 1]
   })

--- a/example/bunny.js
+++ b/example/bunny.js
@@ -46,6 +46,8 @@ const drawBunny = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   regl.clear({
     depth: 1,
     color: [0, 0, 0, 1]

--- a/example/camera.js
+++ b/example/camera.js
@@ -45,6 +45,8 @@ const drawBunny = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   regl.clear({
     color: [0, 0, 0, 1]
   })

--- a/example/cloth.js
+++ b/example/cloth.js
@@ -216,6 +216,8 @@ require('resl')({
 
   onDone: ({ clothTexture }) => {
     regl.frame(({tick}) => {
+      regl.updateTimer()
+
       const deltaTime = 0.017
 
       regl.clear({

--- a/example/cube.js
+++ b/example/cube.js
@@ -83,6 +83,8 @@ require('resl')({
   },
   onDone: ({texture}) => {
     regl.frame(() => {
+      regl.updateTimer()
+
       regl.clear({
         color: [0, 0, 0, 255],
         depth: 1

--- a/example/dds.js
+++ b/example/dds.js
@@ -94,6 +94,8 @@ require('resl')({
     })
 
     regl.frame(() => {
+      regl.updateTimer()
+
       draw()
     })
   }

--- a/example/dynamic.js
+++ b/example/dynamic.js
@@ -40,6 +40,8 @@ const draw = regl({
 })
 
 regl.frame(({tick}) => {
+  regl.updateTimer()
+
   regl.clear({
     color: [0, 0, 0, 1]
   })

--- a/example/envmap.js
+++ b/example/envmap.js
@@ -110,6 +110,8 @@ require('resl')({
       posy, negy,
       posz, negz)
     regl.frame(() => {
+      regl.updateTimer()
+
       setupEnvMap({ cube }, () => {
         drawBackground()
         drawBunny()

--- a/example/feedback.js
+++ b/example/feedback.js
@@ -52,6 +52,8 @@ const drawFeedback = regl({
 })
 
 regl.frame(function () {
+  regl.updateTimer()
+
   regl.clear({
     color: [0, 0, 0, 1]
   })

--- a/example/geomorph.js
+++ b/example/geomorph.js
@@ -138,6 +138,8 @@ const drawBunnyWithLOD = regl({
 })
 
 regl.frame(({tick}) => {
+  regl.updateTimer()
+
   regl.clear({
     depth: 1,
     color: [0, 0, 0, 1]

--- a/example/life.js
+++ b/example/life.js
@@ -69,6 +69,8 @@ const setupQuad = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   setupQuad(() => {
     regl.draw()
     updateLife()

--- a/example/lighting.js
+++ b/example/lighting.js
@@ -95,6 +95,8 @@ const drawBunny = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   regl.clear({
     depth: 1,
     color: [0, 0, 0, 1]

--- a/example/microphone.js
+++ b/example/microphone.js
@@ -63,6 +63,8 @@ require('getusermedia')({audio: true}, function (err, stream) {
   })
 
   regl.frame(({tick}) => {
+    regl.updateTimer()
+
     // Clear draw buffer
     regl.clear({
       color: [0, 0, 0, 1],

--- a/example/minecraft.js
+++ b/example/minecraft.js
@@ -194,6 +194,8 @@ require('resl')({
 
   onDone: ({ atlas }) => {
     regl.frame(() => {
+      regl.updateTimer()
+
       drawWorld({position, elements, uv, normal, atlas})
       camera.tick()
     })

--- a/example/mipmap.js
+++ b/example/mipmap.js
@@ -55,5 +55,7 @@ const drawCheckerboard = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   drawCheckerboard()
 })

--- a/example/particles.js
+++ b/example/particles.js
@@ -89,6 +89,8 @@ const drawParticles = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   regl.clear({
     depth: 1,
     color: [0, 0, 0, 1]

--- a/example/pong.js
+++ b/example/pong.js
@@ -247,6 +247,8 @@ const drawAabb = regl({
 resetBall(true)
 
 regl.frame(function ({viewportWidth, viewportHeight, pixelRatio}) {
+  regl.updateTimer()
+
   regl.clear({
     color: [0, 0, 0, 1]
   })

--- a/example/stats.js
+++ b/example/stats.js
@@ -195,6 +195,8 @@ var statsWidget = createStatsWidget(drawCalls)
 regl.frame(() => {
   regl.updateTimer()
 
+  regl.updateTimer()
+
   regl.clear({
     color: [0, 0, 0, 255],
     depth: 1

--- a/example/text.js
+++ b/example/text.js
@@ -97,6 +97,8 @@ const drawText = regl({
 })
 
 regl.frame(() => {
+  regl.updateTimer()
+
   drawFeedback()
   drawText()
   feedBackTexture({

--- a/example/theta360.js
+++ b/example/theta360.js
@@ -99,6 +99,8 @@ require('resl')({
   },
   onDone: () => {
     regl.frame(({tick}) => {
+      regl.updateTimer()
+
       const t = 0.01 * tick
       setupEnvMap({
         view: mat4.lookAt([],

--- a/example/tile.js
+++ b/example/tile.js
@@ -56,6 +56,8 @@ require('resl')({
     })
 
     regl.frame(({viewportWidth, viewportHeight}) => {
+      regl.updateTimer()
+
       const {x, y} = mouse
 
       const boxX = map[0].length * x / viewportWidth

--- a/example/video.js
+++ b/example/video.js
@@ -70,6 +70,8 @@ require('resl')({
 
     const texture = regl.texture(video)
     regl.frame(() => {
+      regl.updateTimer()
+
       drawDoggie({ video: texture.subimage(video) })
     })
   }


### PR DESCRIPTION
Currently, you have to call `regl.updateTimer` for every frame. Otherwise, you will keep on creating and starting queries without ever finishing them, and this causes the performance to get worse and worse. So I added `regl.updateTimer()` to the beginning of every frame in the examples. 