### PR TITLE
Remove `updateTimer()` from `deferred_shading.js`

### DIFF
--- a/example/deferred_shading.js
+++ b/example/deferred_shading.js
@@ -411,8 +411,6 @@ var drawPointLights = (tick) => {
 }
 
 regl.frame(({tick, viewportWidth, viewportHeight}) => {
-  regl.updateTimer()
-
   fbo.resize(viewportWidth, viewportHeight)
 
   globalScope(() => {


### PR DESCRIPTION
Remove `updateTimer()` from `deferred_shading.js`, since it has been removed from the API.
