### PR TITLE
Remove "Shadow mapping" from list of examples. Add more example items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,10 +54,11 @@
 * Recipe book/example set
     + Globe
     + Compound scene
-    + Shadow mapping
     + Stencil shadows
+    + Point-light shadows(through cubic framebuffers)
     + Turing patterns
     + Asset loading (obj, ply, etc.)
+    + Water Reflection(though cubic-framebuffers)
 
 ## Next
 


### PR DESCRIPTION
Remove "Shadow mapping" from list of examples. Since it has been implemented now.

Add two new example items.