### PR TITLE
Added Framebuffer bit planes validation

### DIFF
--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -20,6 +20,10 @@ var GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT = 0x8CD7
 var GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8CD9
 var GL_FRAMEBUFFER_UNSUPPORTED = 0x8CDD
 
+var GL_HALF_FLOAT_OES = 0x8D61
+var GL_UNSIGNED_BYTE = 0x1401
+var GL_FLOAT = 0x1406
+
 var GL_RGBA = 0x1908
 var GL_ALPHA = 0x1906
 var GL_RGB = 0x1907
@@ -35,6 +39,22 @@ var colorTextureFormatEnums = [
   GL_RGB,
   GL_RGBA
 ]
+
+// for every texture format, store
+// the number of channels
+var textureFormatChannels = []
+textureFormatChannels[GL_ALPHA] = 1
+textureFormatChannels[GL_LUMINANCE] = 1
+textureFormatChannels[GL_LUMINANCE_ALPHA] = 2
+textureFormatChannels[GL_RGB] = 3
+textureFormatChannels[GL_RGBA] = 4
+
+// for every texture type, store
+// the size in bytes.
+var textureTypeSizes = []
+textureTypeSizes[GL_UNSIGNED_BYTE] = 1
+textureTypeSizes[GL_FLOAT] = 4
+textureTypeSizes[GL_HALF_FLOAT_OES] = 2
 
 var GL_RGBA4 = 0x8056
 var GL_RGB5_A1 = 0x8057
@@ -530,6 +550,8 @@ module.exports = function wrapFBOState (
         (!!depthBuffer) + (!!stencilBuffer) + (!!depthStencilBuffer) <= 1,
         'invalid framebuffer configuration, can specify exactly one depth/stencil attachment')
 
+      var commonColorAttachmentSize = null
+
       for (i = 0; i < colorAttachments.length; ++i) {
         incRefAndCheckShape(colorAttachments[i], width, height)
         check(!colorAttachments[i] ||
@@ -538,6 +560,22 @@ module.exports = function wrapFBOState (
           (colorAttachments[i].renderbuffer &&
             colorRenderbufferFormatEnums.indexOf(colorAttachments[i].renderbuffer._renderbuffer.format) >= 0),
           'framebuffer color attachment ' + i + ' is invalid')
+
+        if (colorAttachments[i] && colorAttachments[i].texture) {
+          var colorAttachmentSize =
+              textureFormatChannels[colorAttachments[i].texture._texture.format] *
+              textureTypeSizes[colorAttachments[i].texture._texture.type]
+
+          if (commonColorAttachmentSize === null) {
+            commonColorAttachmentSize = colorAttachmentSize
+          } else {
+            // We need to make sure that all color attachments have the same number of bitplanes
+            // (that is, the same numer of bits per pixel)
+            // This is required by the GLES2.0 standard. See the beginning of Chapter 4 in that document.
+            check(commonColorAttachmentSize === colorAttachmentSize,
+                  'all color attachments much have the same number of bits per pixel.')
+          }
+        }
       }
       incRefAndCheckShape(depthAttachment, width, height)
       check(!depthAttachment ||

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -195,46 +195,48 @@ tape('framebuffer parsing', function (t) {
 
   // TODO: float, half float types
 
-  t.throws(function () {
-    regl.framebuffer({
-      color: [
-        regl.texture({type: 'float'}),
-        regl.texture({type: 'uint8'})
-      ]}) },
-           /\(regl\)/,
-           '#1 check color attachments with different bit planes throws')
+  if (regl.hasExtension('WEBGL_draw_buffers')) {
+    t.throws(function () {
+      regl.framebuffer({
+        color: [
+          regl.texture({type: 'float'}),
+          regl.texture({type: 'uint8'})
+        ]}) },
+             /\(regl\)/,
+             '#1 check color attachments with different bit planes throws')
 
-  t.throws(function () {
-    regl.framebuffer({
-      color: [
-        regl.texture({type: 'uint8', format: 'rgb'}),
-        regl.texture({type: 'float', format: 'rgba'})
-      ]}) },
-           /\(regl\)/,
-           '#2 check color attachments with different bit planes throws')
+    t.throws(function () {
+      regl.framebuffer({
+        color: [
+          regl.texture({type: 'uint8', format: 'rgb'}),
+          regl.texture({type: 'float', format: 'rgba'})
+        ]}) },
+             /\(regl\)/,
+             '#2 check color attachments with different bit planes throws')
 
-  t.throws(function () {
-    regl.framebuffer({
-      color: [
-        regl.texture({type: 'half float', format: 'rgb'}),
-        regl.texture({type: 'uint8', format: 'rgba'})
-      ]}) },
-           /\(regl\)/,
-           '#3 check color attachments with different bit planes throws')
+    t.throws(function () {
+      regl.framebuffer({
+        color: [
+          regl.texture({type: 'half float', format: 'rgb'}),
+          regl.texture({type: 'uint8', format: 'rgba'})
+        ]}) },
+             /\(regl\)/,
+             '#3 check color attachments with different bit planes throws')
 
-  var thrown = false
-  try {
-    regl.framebuffer({
-      color: [
-        regl.texture({type: 'float'}),
-        regl.texture({type: 'float'})
-      ]})
-  } catch (e) {
-    thrown = true
+    var thrown = false
+    try {
+      regl.framebuffer({
+        color: [
+          regl.texture({type: 'float'}),
+          regl.texture({type: 'float'})
+        ]})
+    } catch (e) {
+      thrown = true
+    }
+
+    // TODO: multiple render targets
+    t.equals(thrown, false, 'check color attachments with same bit planes do not throw')
   }
-
-  // TODO: multiple render targets
-  t.equals(thrown, false, 'check color attachments with same bit planes do not throw')
 
   regl.destroy()
   createContext.destroy(gl)

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -194,7 +194,47 @@ tape('framebuffer parsing', function (t) {
     'color renderbuffer')
 
   // TODO: float, half float types
+
+  t.throws(function () {
+    regl.framebuffer({
+      color: [
+        regl.texture({type: 'float'}),
+        regl.texture({type: 'uint8'})
+      ]}) },
+           /\(regl\)/,
+           '#1 check color attachments with different bit planes throws')
+
+  t.throws(function () {
+    regl.framebuffer({
+      color: [
+        regl.texture({type: 'uint8', format: 'rgb'}),
+        regl.texture({type: 'float', format: 'rgba'})
+      ]}) },
+           /\(regl\)/,
+           '#2 check color attachments with different bit planes throws')
+
+  t.throws(function () {
+    regl.framebuffer({
+      color: [
+        regl.texture({type: 'half float', format: 'rgb'}),
+        regl.texture({type: 'uint8', format: 'rgba'})
+      ]}) },
+           /\(regl\)/,
+           '#3 check color attachments with different bit planes throws')
+
+  var thrown = false
+  try {
+    regl.framebuffer({
+      color: [
+        regl.texture({type: 'float'}),
+        regl.texture({type: 'float'})
+      ]})
+  } catch (e) {
+    thrown = true
+  }
+
   // TODO: multiple render targets
+  t.equals(thrown, false, 'check color attachments with same bit planes do not throw')
 
   regl.destroy()
   createContext.destroy(gl)


### PR DESCRIPTION
This PR adds validation logic that prevents us from creating an FBO with render targets that have differing bitplanes. This resolves issue #64. 