### PR TITLE
Fix gl.LINES quote typo.

### DIFF
--- a/API.md
+++ b/API.md
@@ -604,7 +604,7 @@ var command = regl({
 | Primitive type | Description |
 |-------|-------------|
 | `'points'` | `gl.POINTS` |
-| `'lines'` | gl.LINES` |
+| `'lines'` | `gl.LINES` |
 | `'line strip'` | `gl.LINE_STRIP` |
 | `'line loop` | `gl.LINE_LOOP` |
 | `'triangles` | `gl.TRIANGLES` |


### PR DESCRIPTION
Fix gl.LINES quote typo.

Fixed from

gl.LINES`

to 

`gl.LINES`