### PR TITLE
`lib/core.js`: Insert missing `check.optional` in emitCount().

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2598,7 +2598,9 @@ module.exports = function reglCore (
         })
       } else {
         COUNT = scope.def(DRAW_STATE, '.', S_COUNT)
-        env.assert(scope, COUNT + '>=0', 'missing vertex count')
+        check.optional(function () {
+          env.assert(scope, COUNT + '>=0', 'missing vertex count')
+        })
       }
       return COUNT
     }


### PR DESCRIPTION
In `lib/core.js` there was a missing `check.optional` for `assert` in `emitCount()`. This meant that for some programs built for the gallery(and all programs built for production), you would only get the error

```
stats.js.html:62 Uncaught TypeError: a.assert is not a function
```

And white screen. This PR fixes that.