### PR TITLE
Fix the instance examples

### DIFF
--- a/example/instance-mesh.js
+++ b/example/instance-mesh.js
@@ -9,7 +9,7 @@ const fit = require('canvas-fit')
 const normals = require('angle-normals')
 
 const canvas = document.body.appendChild(document.createElement('canvas'))
-const regl = require('../regl')(canvas)
+const regl = require('../regl')({canvas: canvas, extensions: ['angle_instanced_arrays']})
 const camera = require('canvas-orbit-camera')(canvas)
 window.addEventListener('resize', fit(canvas), false)
 

--- a/example/instance-triangle.js
+++ b/example/instance-triangle.js
@@ -2,7 +2,7 @@
   In this example, it is shown how you can draw a bunch of triangles using the
   instancing feature of regl.
  */
-const regl = require('../regl')()
+const regl = require('../regl')({extensions: ['angle_instanced_arrays']})
 
 var N = 10 // N triangles on the width, N triangles on the height.
 


### PR DESCRIPTION
Fix so that the instance examples `example/instance-mesh.js` and `example/instance-triangle.js`
use the new extension loading mechanism in the `regl` constructor.