### PR TITLE
lib/texture.js: fix 'rgb arc' => 'rgb atc'

### DIFF
--- a/lib/texture.js
+++ b/lib/texture.js
@@ -380,7 +380,7 @@ module.exports = function createTextureSet (
 
   if (extensions.webgl_compressed_texture_atc) {
     extend(compressedTextureFormats, {
-      'rgb arc': GL_COMPRESSED_RGB_ATC_WEBGL,
+      'rgb atc': GL_COMPRESSED_RGB_ATC_WEBGL,
       'rgba atc explicit alpha': GL_COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL,
       'rgba atc interpolated alpha': GL_COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL
     })


### PR DESCRIPTION
Change from the misspelling 'rgb arc' to 'rgb atc'.