### PR TITLE
0.10.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,18 +2,17 @@
 
 ## Planned
 
-* Add a mechanism for users to specify minimum resource requirements (texture size, varying units, etc.)
-
 * Cubic frame buffer objects
-
-* Context loss
-
-* Write comparison suite
 
 * More performance monitoring hooks
     + Track currently used resource requirements
     + Output should be serializable -> works as input to constructor checks
 
+* Context loss
+
+* Write comparison suite
+
+* Add a mechanism for users to specify minimum resource requirements (texture size, varying units, etc.)
 * More validation
     + Should not be possible to write regl code that crashes on some systems
 
@@ -56,11 +55,14 @@
 
 ## Next
 
-* Add more test cases for `regl.read()` and improve validation
-* Implement a standard method for handling context creation errors
+## 0.10.0
+
 * Add a mechanism for managing webgl extensions
     + Should be able to report errors when extensions are missing
     + Allow users to disable extensions for testing/mocking
+* Doc clean up
+* Add more test cases for `regl.read()` and improve validation
+* Implement a standard method for handling context creation errors
 * Fix several bugs related to `regl.frame` cancellation
 
 ## 0.9.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regl",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Regl is a fast functional reactive abstraction for WebGL.",
   "main": "regl.js",
   "directories": {


### PR DESCRIPTION
Changes:

* Add a mechanism for managing webgl extensions
    + Should be able to report errors when extensions are missing
    + Allow users to disable extensions for testing/mocking
* Doc clean up
* Add more test cases for `regl.read()` and improve validation
* Implement a standard method for handling context creation errors
* Fix several bugs related to `regl.frame` cancellation
