### PR TITLE
Update npmignore, should not publish code coverage results

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,7 @@ test/*
 www/*
 bin/*
 dist/*
+coverage/*
+images/*
+compare/*
 CNAME


### PR DESCRIPTION
Added a few more directories to the npmignore list.  We shouldn't be publishing the code coverage results, comparison scripts or test images.