### PR TITLE
 test/batch-attributes.js: remove TODO for instancing tests.

### DIFF
--- a/test/batch-attributes.js
+++ b/test/batch-attributes.js
@@ -142,11 +142,6 @@ tape('batch mode attributes', function (t) {
     0, 0, 0, 0, 0
   ], 'offset - batch')
 
-  // check instancing
-  if (gl.getExtension('angle_instanced_arrays')) {
-    // todo
-  }
-
   regl.destroy()
   createContext.destroy(gl)
   t.end()


### PR DESCRIPTION
 Remove TODO for instancing tests, since was solved in PR #81