### PR TITLE
Load optional extensions in test cases

### DIFF
--- a/test/framebuffer-depth-stencil.js
+++ b/test/framebuffer-depth-stencil.js
@@ -6,7 +6,10 @@ tape('framebuffer - depth stencil attachment', function (t) {
   var N = 5
 
   var gl = createContext(N, N)
-  var regl = createREGL(gl)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: 'webgl_depth_texture'
+  })
 
   var drawLine = regl({
     frag: [

--- a/test/framebuffer-mrt.js
+++ b/test/framebuffer-mrt.js
@@ -4,7 +4,10 @@ var tape = require('tape')
 
 tape('framebuffer - multiple draw buffers', function (t) {
   var gl = createContext(16, 16)
-  var regl = createREGL(gl)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: 'webgl_draw_buffers'
+  })
 
   var renderTexture = regl({
     vert: [

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -4,7 +4,10 @@ var tape = require('tape')
 
 tape('framebuffer parsing', function (t) {
   var gl = createContext(16, 16)
-  var regl = createREGL(gl)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: 'webgl_draw_buffers'
+  })
 
   function checkProperties (framebuffer, props, prefix) {
     var _framebuffer = framebuffer._framebuffer

--- a/test/renderbuffer.js
+++ b/test/renderbuffer.js
@@ -4,7 +4,10 @@ var tape = require('tape')
 
 tape('renderbuffer parsing', function (t) {
   var gl = createContext(16, 16)
-  var regl = createREGL(gl)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: ['ext_srgb', 'ext_color_buffer_half_float', 'webgl_color_buffer_float']
+  })
 
   function checkProperties (prefix, renderbuffer, props) {
     t.equals(gl.getError(), 0, prefix + ' no gl error')

--- a/test/texture2d.js
+++ b/test/texture2d.js
@@ -7,7 +7,7 @@ tape('texture 2d', function (t) {
   var regl = createREGL(
     {
       gl: gl,
-      optionalExtensions: ['webgl_compressed_texture_s3tc']
+      optionalExtensions: ['webgl_compressed_texture_s3tc', 'ext_texture_filter_anisotropic']
     })
 
   var renderTexture = regl({

--- a/test/textureCube.js
+++ b/test/textureCube.js
@@ -4,7 +4,10 @@ var tape = require('tape')
 
 tape('texture cube', function (t) {
   var gl = createContext(16, 16)
-  var regl = createREGL(gl)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: ['ext_texture_filter_anisotropic']
+  })
 
   var renderCubeFace = regl({
     vert: [


### PR DESCRIPTION
Not all the tests were loading all the optional extensions they were using. Fixed that.
