### PR TITLE
Improve framebuffer test cases

### DIFF
--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -25,25 +25,16 @@ var GL_UNSIGNED_BYTE = 0x1401
 var GL_FLOAT = 0x1406
 
 var GL_RGBA = 0x1908
-var GL_ALPHA = 0x1906
-var GL_LUMINANCE = 0x1909
-var GL_LUMINANCE_ALPHA = 0x190A
 
 var GL_DEPTH_COMPONENT = 0x1902
 
 var colorTextureFormatEnums = [
-  GL_ALPHA,
-  GL_LUMINANCE,
-  GL_LUMINANCE_ALPHA,
   GL_RGBA
 ]
 
 // for every texture format, store
 // the number of channels
 var textureFormatChannels = []
-textureFormatChannels[GL_ALPHA] = 1
-textureFormatChannels[GL_LUMINANCE] = 1
-textureFormatChannels[GL_LUMINANCE_ALPHA] = 2
 textureFormatChannels[GL_RGBA] = 4
 
 // for every texture type, store

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -331,8 +331,10 @@ module.exports = function wrapFBOState (
 
       var extDrawBuffers = extensions.webgl_draw_buffers
 
-      var width = 0
-      var height = 0
+      // default dimensions should be 1x1.
+      // 0x0 is considered invalid.
+      var width = 1
+      var height = 1
 
       var needsDepth = true
       var needsStencil = true
@@ -349,8 +351,8 @@ module.exports = function wrapFBOState (
       var depthStencilTexture = false
 
       if (typeof a === 'number') {
-        width = a | 0
-        height = (b | 0) || width
+        width = a | 1
+        height = (b | 1) || width
       } else if (!a) {
         width = height = 1
       } else {

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -26,7 +26,6 @@ var GL_FLOAT = 0x1406
 
 var GL_RGBA = 0x1908
 var GL_ALPHA = 0x1906
-var GL_RGB = 0x1907
 var GL_LUMINANCE = 0x1909
 var GL_LUMINANCE_ALPHA = 0x190A
 
@@ -36,7 +35,6 @@ var colorTextureFormatEnums = [
   GL_ALPHA,
   GL_LUMINANCE,
   GL_LUMINANCE_ALPHA,
-  GL_RGB,
   GL_RGBA
 ]
 
@@ -46,7 +44,6 @@ var textureFormatChannels = []
 textureFormatChannels[GL_ALPHA] = 1
 textureFormatChannels[GL_LUMINANCE] = 1
 textureFormatChannels[GL_LUMINANCE_ALPHA] = 2
-textureFormatChannels[GL_RGB] = 3
 textureFormatChannels[GL_RGBA] = 4
 
 // for every texture type, store

--- a/lib/framebuffer.js
+++ b/lib/framebuffer.js
@@ -331,10 +331,8 @@ module.exports = function wrapFBOState (
 
       var extDrawBuffers = extensions.webgl_draw_buffers
 
-      // default dimensions should be 1x1.
-      // 0x0 is considered invalid.
-      var width = 1
-      var height = 1
+      var width = 0
+      var height = 0
 
       var needsDepth = true
       var needsStencil = true
@@ -351,8 +349,8 @@ module.exports = function wrapFBOState (
       var depthStencilTexture = false
 
       if (typeof a === 'number') {
-        width = a | 1
-        height = (b | 1) || width
+        width = a | 0
+        height = (b | 0) || width
       } else if (!a) {
         width = height = 1
       } else {

--- a/lib/texture.js
+++ b/lib/texture.js
@@ -580,20 +580,20 @@ module.exports = function createTextureSet (
         check(c > 0 && c <= 4, 'invalid number of channels')
         hasChannels = true
       }
-      check(w > 0 && w <= limits.maxTextureSize, 'invalid width')
-      check(h > 0 && h <= limits.maxTextureSize, 'invalid height')
+      check(w >= 0 && w <= limits.maxTextureSize, 'invalid width')
+      check(h >= 0 && h <= limits.maxTextureSize, 'invalid height')
     } else {
       if ('radius' in options) {
         w = h = options.radius
-        check(w > 0 && w <= limits.maxTextureSize, 'invalid radius')
+        check(w >= 0 && w <= limits.maxTextureSize, 'invalid radius')
       }
       if ('width' in options) {
         w = options.width
-        check(w > 0 && w <= limits.maxTextureSize, 'invalid width')
+        check(w >= 0 && w <= limits.maxTextureSize, 'invalid width')
       }
       if ('height' in options) {
         h = options.height
-        check(h > 0 && h <= limits.maxTextureSize, 'invalid height')
+        check(h >= 0 && h <= limits.maxTextureSize, 'invalid height')
       }
       if ('channels' in options) {
         c = options.channels

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -58,12 +58,10 @@ tape('framebuffer parsing', function (t) {
           label + ' object assoc')
       } else {
         t.equals(actual.renderbuffer, null, label + '.renderbuffer')
-        /*
         t.equals(
-          actual.texture._texture.params.internalformat,
+          actual.texture._texture.internalformat,
           expected.format,
           label + '.format')
-        */
         t.equals(actual.texture.width, props.width, label + '.width')
         t.equals(actual.texture.height, props.height, label + '.height')
         t.equals(

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -215,15 +215,22 @@ tape('framebuffer parsing', function (t) {
     {tex: false, colorFormat: 'rgb5 a1', expectedFormat: gl.RGB5_A1}
   ]
 
+  // these test cases should fail.
+  var badTestCases = [
+    {colorFormat: 'alpha', colorType: 'uint8'},
+    {colorFormat: 'luminance', colorType: 'uint8'},
+    {colorFormat: 'luminance alpha', colorType: 'uint8'}
+  ]
+
   if (regl.hasExtension('oes_texture_float')) {
     testCases.push({tex: true, colorFormat: 'rgba', colorType: 'float', expectedFormat: gl.RGBA, expectedType: gl.FLOAT})
-   // testCases.push({tex: true, colorFormat: 'rgb', colorType: 'float', expectedFormat: gl.RGB, expectedType: gl.FLOAT})
+    badTestCases.push({colorFormat: 'rgb', colorType: 'float'})
   }
 
   if (regl.hasExtension('oes_texture_half_float')) {
     var GL_HALF_FLOAT_OES = 0x8D61
     testCases.push({tex: true, colorFormat: 'rgba', colorType: 'half float', expectedFormat: gl.RGBA, expectedType: GL_HALF_FLOAT_OES})
-//    testCases.push({tex: true, colorFormat: 'rgb', colorType: 'half float', expectedFormat: gl.RGB, expectedType: GL_HALF_FLOAT_OES})
+    badTestCases.push({colorFormat: 'rgb', colorType: 'half float'})
   }
 
   // We'll skip testing the renderbuffer formats rgba32f, rgba16f, rgb16f.
@@ -269,6 +276,19 @@ tape('framebuffer parsing', function (t) {
         }
       },
       'for colorFormat=' + testCase.colorFormat + (testCase.tex ? (' and colorType=' + testCase.colorType) : ''))
+  })
+
+  badTestCases.forEach(function (testCase, i) {
+    var fboArgs = {
+      shape: [10, 10],
+      colorFormat: testCase.colorFormat,
+      colorType: testCase.colorType
+    }
+
+    t.throws(
+      function () { regl.framebuffer(fboArgs) },
+        /\(regl\)/,
+      'throws for colorFormat=' + testCase.colorFormat + ' and colorType=' + testCase.colorType)
   })
 
   if (

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -6,7 +6,7 @@ tape('framebuffer parsing', function (t) {
   var gl = createContext(16, 16)
   var regl = createREGL({
     gl: gl,
-    optionalExtensions: 'webgl_draw_buffers'
+    optionalExtensions: ['webgl_draw_buffers', 'oes_texture_float', 'oes_texture_half_float']
   })
 
   function checkProperties (framebuffer, props, prefix) {
@@ -197,8 +197,31 @@ tape('framebuffer parsing', function (t) {
     'color renderbuffer')
 
   // TODO: float, half float types
+  /* checkProperties(
+    regl.framebuffer({
+      shape: [10, 10],
+      colorType: 'uint8',
+      colorFormat: 'rgba'
+    }),
+    {
+      width: 10,
+      height: 10,
+      color: [{
+        target: gl.TEXTURE_2D,
+        format: gl.RGBA,
+        //        type: gl.UNSIGNED_BYTE
+        type: gl.FLOAT
 
-  if (regl.hasExtension('WEBGL_draw_buffers')) {
+      }],
+      depthStencil: {
+        target: gl.RENDERBUFFER,
+        format: gl.DEPTH_STENCIL
+      }
+    },
+    'testing')
+*/
+  if (
+    regl.hasExtension('WEBGL_draw_buffers') && regl.hasExtension('oes_texture_float') && regl.hasExtension('oes_texture_half_float')) {
     t.throws(function () {
       regl.framebuffer({
         color: [
@@ -237,9 +260,10 @@ tape('framebuffer parsing', function (t) {
       thrown = true
     }
 
-    // TODO: multiple render targets
     t.equals(thrown, false, 'check color attachments with same bit planes do not throw')
   }
+
+  // TODO: multiple render targets
 
   regl.destroy()
   createContext.destroy(gl)

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -291,8 +291,36 @@ tape('framebuffer parsing', function (t) {
       'throws for colorFormat=' + testCase.colorFormat + ' and colorType=' + testCase.colorType)
   })
 
+  // we create the maximum number of possible color attachments.
+  // and make that colorType and colorFormat is applied for them all.
+  if (regl.hasExtension('webgl_draw_buffers')) {
+    var expected = {
+      width: 1,
+      height: 1,
+      color: [],
+      depthStencil: {
+        target: gl.RENDERBUFFER,
+        format: gl.DEPTH_STENCIL
+      }
+    }
+
+    for (var i = 0; i < regl.limits.maxColorAttachments; i++) {
+      expected.color[i] = {target: gl.TEXTURE_2D, format: gl.RGBA, type: gl.UNSIGNED_BYTE}
+    }
+
+    checkProperties(
+      regl.framebuffer({colorFormat: 'rgba', colorType: 'uint8', colorCount: regl.limits.maxColorAttachments}),
+      expected,
+      'for MRT with colorCount: ' + regl.limits.maxColorAttachments)
+
+    t.throws(
+      function () { regl.framebuffer({colorFormat: 'rgba', colorType: 'uint8', colorCount: regl.limits.maxColorAttachments + 1}) },
+        /\(regl\)/,
+      'throws for exceeding regl.limits.maxColorAttachments')
+  }
+
   if (
-    regl.hasExtension('WEBGL_draw_buffers') && regl.hasExtension('oes_texture_float') && regl.hasExtension('oes_texture_half_float')) {
+    regl.hasExtension('webgl_draw_buffers') && regl.hasExtension('oes_texture_float') && regl.hasExtension('oes_texture_half_float')) {
     t.throws(function () {
       regl.framebuffer({
         color: [

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -62,6 +62,10 @@ tape('framebuffer parsing', function (t) {
           actual.texture._texture.internalformat,
           expected.format,
           label + '.format')
+        t.equals(
+          actual.texture._texture.type,
+          expected.type,
+          label + '.type')
         t.equals(actual.texture.width, props.width, label + '.width')
         t.equals(actual.texture.height, props.height, label + '.height')
         t.equals(
@@ -122,7 +126,8 @@ tape('framebuffer parsing', function (t) {
       height: 1,
       color: [{
         target: gl.TEXTURE_2D,
-        format: gl.RGBA
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE
       }],
       depthStencil: {
         target: gl.RENDERBUFFER,
@@ -142,7 +147,8 @@ tape('framebuffer parsing', function (t) {
       height: 5,
       color: [{
         target: gl.TEXTURE_2D,
-        format: gl.RGBA
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE
       }],
       stencil: {
         target: gl.RENDERBUFFER,
@@ -164,7 +170,7 @@ tape('framebuffer parsing', function (t) {
       height: 10,
       color: [{
         target: gl.RENDERBUFFER,
-        format: gl.RGB5_A1
+        format: gl.RGB5_A1,
       }],
       depthStencil: {
         target: gl.RENDERBUFFER,

--- a/test/framebuffer-resize.js
+++ b/test/framebuffer-resize.js
@@ -4,7 +4,10 @@ var tape = require('tape')
 
 tape('framebuffer resizing', function (t) {
   var gl = createContext(16, 16)
-  var regl = createREGL(gl)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: ['webgl_draw_buffers']
+  })
 
   var fbo = regl.framebuffer(10, 10)
 
@@ -59,6 +62,23 @@ tape('framebuffer resizing', function (t) {
   t.equals(fbo.color[0].height, 3, 'color height ok')
   t.equals(fbo.depthStencil.width, 2, 'depth stencil width ok')
   t.equals(fbo.depthStencil.height, 3, 'depth stencil width ok')
+
+  // now test .resize for MRT.
+  if (regl.hasExtension('webgl_draw_buffers')) {
+    var mrtFbo = regl.framebuffer({colorFormat: 'rgba', colorType: 'uint8', colorCount: regl.limits.maxColorAttachments})
+
+    mrtFbo.resize(2, 3)
+
+    t.equals(mrtFbo.width, 2, 'mrt width ok')
+    t.equals(mrtFbo.height, 3, 'mrt height ok')
+    t.equals(mrtFbo.depthStencil.width, 2, 'mrt depth stencil width ok')
+    t.equals(mrtFbo.depthStencil.height, 3, 'mrt depth stencil width ok')
+
+    for (var i = 0; i < regl.limits.maxColorAttachments; i++) {
+      t.equals(mrtFbo.color[i].width, 2, 'mrt color[' + i + '] width ok')
+      t.equals(mrtFbo.color[i].height, 3, 'mrt color[' + i + '] height ok')
+    }
+  }
 
   regl.destroy()
   createContext.destroy(gl)

--- a/test/texture2d.js
+++ b/test/texture2d.js
@@ -296,10 +296,6 @@ tape('texture 2d', function (t) {
       ]
     }, '2d nested array')
 
-  checkShouldThrow({
-    shape: [0, 0]
-  }, '0x0')
-
   checkProperties(
     regl.texture({
       shape: [2, 2, 2],


### PR DESCRIPTION
This PR adds more test cases for framebuffers, and fixes several edge cases in framebuffers.

* Test cases for `colorFormat`, `colorType` and `colorCount` are added, thus resolving issue #61.
* We remove support for color attachments with the formats `GL_LUMINANCE`. `GL_ALPHA`, `GL_LUMINANCE_ALPHA`, since they are not renderable. Supporting them in the first place was a mistake, since they did not work. Also `GL_RGB` is removed, due to spotty browser support(did not work in Firefox).
* Add test cases for `framebuffer.resize()` for MRT.

* Before this PR, you could not create an FBO like this:

```javascript
const fbo = regl.framebuffer({
  colorType: 'float',
  colorFormat: 'rgba',
  colorCount: 3,
  depth: true
})
```

because the three color attachments would default to width and height of 0, and textures with such width and heights were considered invalid, for some reason. But now they are valid, so the above now works.