### PR TITLE
Implement `regl.read` for framebuffers of type `uint8` and `float`

### DIFF
--- a/API.md
+++ b/API.md
@@ -2107,7 +2107,7 @@ var pixels = regl.read({
 })
 
 // You can also read from the currently bound fbo.
-// Note that `pixels`  will be of type `Float32Array`
+// Note that `pixels` will be of type `Float32Array`
 // in this case.
 fbo = regl.framebuffer({
   width: W,
@@ -2137,7 +2137,6 @@ regl({framebuffer: fbo})(() => {
 
 * You can only read pixels from a framebuffer of type `'uint8'` or
   `'float'`. Furthermore, it is not possible to read from a renderbuffer.
-  renderbuffer.
 
 **Relevant WebGL APIs**
 

--- a/API.md
+++ b/API.md
@@ -2105,6 +2105,20 @@ var pixels = regl.read({
   height: 1,
   data: new Uint8Array(12)
 })
+
+// You can also read from the currently bound fbo.
+// Note that `pixels`  will be of type `Float32Array`
+// in this case.
+fbo = regl.framebuffer({
+  width: W,
+  height: H,
+  colorFormat: 'rgba',
+  colorType: 'float'
+})
+regl({framebuffer: fbo})(() => {
+  regl.clear({color: [0.5, 0.25, 0.5, 0.25]})
+  var pixels = regl.read()
+})
 ```
 
 | Property | Description | Default |
@@ -2117,7 +2131,13 @@ var pixels = regl.read({
 
 **Notes**
 
-* In order to read pixels from the drawing buffer, you must create your webgl context with `preserveDrawingBuffer` set to `true`.  If this is not set, then `regl.read` will throw an exception.
+* In order to read pixels from the drawing buffer, you must create
+  your webgl context with `preserveDrawingBuffer` set to `true`.  If
+  this is not set, then `regl.read` will throw an exception.
+
+* You can only read pixels from a framebuffer of type `'uint8'` or
+  `'float'`. Furthermore, it is not possible to read from a renderbuffer.
+  renderbuffer.
 
 **Relevant WebGL APIs**
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -21,6 +21,9 @@ module.exports = function wrapReadPixels (
         'you must create a webgl context with "preserveDrawingBuffer":true in order to read pixels from the drawing buffer')
       type = GL_UNSIGNED_BYTE
     } else {
+      check(
+        framebufferState.next.colorAttachments[0].texture !== null,
+          'You cannot read from a renderbuffer')
       type = framebufferState.next.colorAttachments[0].texture._texture.type
 
       if (extensions.oes_texture_float) {

--- a/lib/read.js
+++ b/lib/read.js
@@ -4,20 +4,34 @@ var isTypedArray = require('./util/is-typed-array')
 var GL_RGBA = 6408
 var GL_UNSIGNED_BYTE = 5121
 var GL_PACK_ALIGNMENT = 0x0D05
+var GL_FLOAT = 0x1406 // 5126
 
 module.exports = function wrapReadPixels (
   gl,
   framebufferState,
   reglPoll,
   context,
-  glAttributes) {
+  glAttributes,
+  extensions) {
   function readPixels (input) {
-    if (framebufferState.current === null) {
+    var type
+    if (framebufferState.next === null) {
       check(
         glAttributes.preserveDrawingBuffer,
         'you must create a webgl context with "preserveDrawingBuffer":true in order to read pixels from the drawing buffer')
+      type = GL_UNSIGNED_BYTE
     } else {
-      // TODO check framebuffer supports read pixels
+      type = framebufferState.next.colorAttachments[0].texture._texture.type
+
+      if (extensions.oes_texture_float) {
+        check(
+          type === GL_UNSIGNED_BYTE || type === GL_FLOAT,
+          'Reading from a framebuffer is only allowed for the types \'uint8\' and \'float\'')
+      } else {
+        check(
+          type === GL_UNSIGNED_BYTE,
+          'Reading from a framebuffer is only allowed for the type \'uint8\'')
+      }
     }
 
     var x = 0
@@ -43,6 +57,19 @@ module.exports = function wrapReadPixels (
       data = input.data || null
     }
 
+    // sanity check input.data
+    if (data) {
+      if (type === GL_UNSIGNED_BYTE) {
+        check(
+          data instanceof Uint8Array,
+          'buffer must be \'Uint8Array\' when reading from a framebuffer of type \'uint8\'')
+      } else if (type === GL_FLOAT) {
+        check(
+          data instanceof Float32Array,
+          'buffer must be \'Float32Array\' when reading from a framebuffer of type \'float\'')
+      }
+    }
+
     check(
       width > 0 && width + x <= context.framebufferWidth,
       'invalid width for read pixels')
@@ -53,15 +80,17 @@ module.exports = function wrapReadPixels (
     // Update WebGL state
     reglPoll()
 
-    // TODO:
-    //  float color buffers
-    //  implementation specific formats
-
     // Compute size
     var size = width * height * 4
 
     // Allocate data
-    data = data || new Uint8Array(size)
+    if (!data) {
+      if (type === GL_UNSIGNED_BYTE) {
+        data = new Uint8Array(size)
+      } else if (type === GL_FLOAT) {
+        data = data || new Float32Array(size)
+      }
+    }
 
     // Type check
     check.isTypedArray(data, 'data buffer for regl.read() must be a typedarray')
@@ -69,7 +98,9 @@ module.exports = function wrapReadPixels (
 
     // Run read pixels
     gl.pixelStorei(GL_PACK_ALIGNMENT, 4)
-    gl.readPixels(x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data)
+    gl.readPixels(x, y, width, height, GL_RGBA,
+                  type,
+                  data)
 
     return data
   }

--- a/regl.js
+++ b/regl.js
@@ -131,7 +131,7 @@ module.exports = function wrapREGL (args) {
     framebufferState,
     core.procs.poll,
     contextState,
-    glAttributes)
+    glAttributes, extensions)
 
   var nextState = core.next
   var canvas = gl.canvas

--- a/test/framebuffer-parse.js
+++ b/test/framebuffer-parse.js
@@ -362,8 +362,6 @@ tape('framebuffer parsing', function (t) {
     t.equals(thrown, false, 'check color attachments with same bit planes do not throw')
   }
 
-  // TODO: multiple render targets
-
   regl.destroy()
   createContext.destroy(gl)
   t.end()

--- a/test/read.js
+++ b/test/read.js
@@ -3,16 +3,35 @@ var createREGL = require('../../regl')
 var tape = require('tape')
 
 tape('read pixels', function (t) {
-  var gl = createContext(5, 5)
-  var regl = createREGL(gl)
+  var W = 5
+  var H = 5
+  var gl = createContext(W, H)
+  var regl = createREGL({
+    gl: gl,
+    optionalExtensions: 'oes_texture_float'
+  })
+
+  function checkFBO (pixels, color, name) {
+    function checkPixels () {
+      for (var i = 0; i < W * H * 4; i += 4) {
+        if (pixels[i] !== color[0] ||
+            pixels[i + 1] !== color[1] ||
+            pixels[i + 2] !== color[2] ||
+            pixels[i + 3] !== color[3]) {
+          return false
+        }
+      }
+      return true
+    }
+
+    t.ok(checkPixels(), name)
+  }
 
   function throws (name, args) {
     t.throws(function () {
       regl.read.apply(regl, args)
     }, /\(regl\)/, name)
   }
-
-  // check fbo validation
 
   // typedarray input
   var bytes = new Uint8Array(100)
@@ -31,6 +50,75 @@ tape('read pixels', function (t) {
   throws('bad offset', [{ x: -2 }])
   throws('bad typedarray', [{data: []}])
   throws('small typedarray', [new Uint8Array(1)])
+
+  // check pixels for default framebuffer
+  regl.clear({color: [0.5, 0, 0, 1]})
+  var pixels = regl.read()
+  checkFBO(pixels, [128, 0, 0, 255], 'read null fbo ok')
+
+  regl.clear({color: [0.5, 0, 0, 1]})
+  pixels = new Uint8Array(W * H * 4)
+  regl.read({data: pixels})
+  checkFBO(pixels, [128, 0, 0, 255], 'read null fbo, reuse buffer, ok')
+
+  pixels = new Float32Array(W * H * 4)
+  throws('attempt use Float32Array to null fbo', [{data: pixels}])
+  throws('attempt use object to null fbo', [{data: {}}])
+
+  // now do it for an uint8 fbo
+  let fbo = regl.framebuffer({
+    width: W,
+    height: H,
+    colorFormat: 'rgba',
+    colorType: 'uint8'
+  })
+  regl({framebuffer: fbo})(() => {
+    regl.clear({color: [0.5, 0, 0, 1]})
+    pixels = regl.read()
+    checkFBO(pixels, [128, 0, 0, 255], 'read uint8 fbo ok')
+  })
+
+  regl({framebuffer: fbo})(() => {
+    regl.clear({color: [0.5, 0, 0, 1]})
+    pixels = new Uint8Array(W * H * 4)
+    regl.read({data: pixels})
+    checkFBO(pixels, [128, 0, 0, 255], 'read uint8 fbo, reuse buffer, ok')
+  })
+
+  regl({framebuffer: fbo})(() => {
+    pixels = new Float32Array(W * H * 4)
+    throws('attempt use Float32Array to uint8 fbo', [{data: pixels}])
+    throws('attempt use object to uint8 fbo', [{data: {}}])
+  })
+
+  // now do it for an float fbo
+  if (regl.hasExtension('oes_texture_float')) {
+    fbo = regl.framebuffer({
+      width: W,
+      height: H,
+      colorFormat: 'rgba',
+      colorType: 'float'
+    })
+
+    regl({framebuffer: fbo})(() => {
+      regl.clear({color: [0.5, 0.25, 0.5, 0.25]})
+      pixels = regl.read()
+      checkFBO(pixels, [0.5, 0.25, 0.5, 0.25], 'read float fbo ok')
+    })
+
+    regl({framebuffer: fbo})(() => {
+      regl.clear({color: [0.5, 0.25, 0.5, 0.25]})
+      pixels = new Float32Array(W * H * 4)
+      regl.read({data: pixels})
+      checkFBO(pixels, [0.5, 0.25, 0.5, 0.25], 'read float fbo, reuse buffer, ok')
+    })
+
+    regl({framebuffer: fbo})(() => {
+      pixels = new Uint8Array(W * H * 4)
+      throws('attempt use Uint8Array to float fbo', [{data: pixels}])
+      throws('attempt use object to float fbo', [{data: {}}])
+    })
+  }
 
   regl.destroy()
   createContext.destroy(gl)

--- a/test/read.js
+++ b/test/read.js
@@ -66,7 +66,7 @@ tape('read pixels', function (t) {
   throws('throws if attempt use object to null fbo', [{data: {}}])
 
   // now do it for an uint8 fbo
-  let fbo = regl.framebuffer({
+  var fbo = regl.framebuffer({
     width: W,
     height: H,
     colorFormat: 'rgba',

--- a/test/read.js
+++ b/test/read.js
@@ -72,20 +72,20 @@ tape('read pixels', function (t) {
     colorFormat: 'rgba',
     colorType: 'uint8'
   })
-  regl({framebuffer: fbo})(() => {
+  regl({framebuffer: fbo})(function () {
     regl.clear({color: [0.5, 0, 0, 1]})
     pixels = regl.read()
     checkFBO(pixels, [128, 0, 0, 255], 'read uint8 fbo ok')
   })
 
-  regl({framebuffer: fbo})(() => {
+  regl({framebuffer: fbo})(function () {
     regl.clear({color: [0.5, 0, 0, 1]})
     pixels = new Uint8Array(W * H * 4)
     regl.read({data: pixels})
     checkFBO(pixels, [128, 0, 0, 255], 'read uint8 fbo, reuse buffer, ok')
   })
 
-  regl({framebuffer: fbo})(() => {
+  regl({framebuffer: fbo})(function () {
     pixels = new Float32Array(W * H * 4)
     throws('throws if attempt use Float32Array to uint8 fbo', [{data: pixels}])
     throws('throws if attempt use object to uint8 fbo', [{data: {}}])
@@ -100,20 +100,20 @@ tape('read pixels', function (t) {
       colorType: 'float'
     })
 
-    regl({framebuffer: fbo})(() => {
+    regl({framebuffer: fbo})(function () {
       regl.clear({color: [0.5, 0.25, 0.5, 0.25]})
       pixels = regl.read()
       checkFBO(pixels, [0.5, 0.25, 0.5, 0.25], 'read float fbo ok')
     })
 
-    regl({framebuffer: fbo})(() => {
+    regl({framebuffer: fbo})(function () {
       regl.clear({color: [0.5, 0.25, 0.5, 0.25]})
       pixels = new Float32Array(W * H * 4)
       regl.read({data: pixels})
       checkFBO(pixels, [0.5, 0.25, 0.5, 0.25], 'read float fbo, reuse buffer, ok')
     })
 
-    regl({framebuffer: fbo})(() => {
+    regl({framebuffer: fbo})(function () {
       pixels = new Uint8Array(W * H * 4)
       throws('throws if attempt use Uint8Array to float fbo', [{data: pixels}])
       throws('throws if attempt use object to float fbo', [{data: {}}])
@@ -134,7 +134,7 @@ tape('read pixels', function (t) {
       width: W,
       height: H
     })
-    regl({framebuffer: fbo})(() => {
+    regl({framebuffer: fbo})(function () {
       throws('attempt to read from renderbuffer of type ' + testCase, [{}])
     })
   })


### PR DESCRIPTION
With this PR, you can `regl.read()` pixels from the currently bound
FBO, and

* if the fbo is of type 'float', you get a Float32Array.
* if the fbo is of type 'uint8', you get a Uint8Array.

For all other types, an exception is thrown. And reading from renderbuffers is not allowed
This PR resolves issue #136