### PR TITLE
Framebuffer uniform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@
 
 ## Next
 
+* Can now use framebuffers as texture.  By default color attachment 0 is used
 * Support for dynamic properties with nested objects like attributes
 * Cubic frame buffer objects
 

--- a/example/blur.js
+++ b/example/blur.js
@@ -274,7 +274,7 @@ const drawFboBlurred = regl({
     position: [ -4, -4, 4, -4, 0, 4 ]
   },
   uniforms: {
-    tex: ({count}) => fbo.color[0],
+    tex: ({count}) => fbo,
     wRcp: ({viewportWidth}) => 1.0 / viewportWidth,
     hRcp: ({viewportHeight}) => 1.0 / viewportHeight
   },

--- a/example/cube-fbo.js
+++ b/example/cube-fbo.js
@@ -161,7 +161,7 @@ const drawBunny = regl({
     projection: regl.context('projection'),
     eye: regl.context('eye'),
     tint: regl.prop('tint'),
-    envMap: bunnyFBO.color[0],
+    envMap: bunnyFBO,
     model: (context, {position}) => mat4.translate(
       [], mat4.identity([]), position)
   }
@@ -196,7 +196,7 @@ const drawTeapot = regl({
     projection: regl.context('projection'),
     eye: regl.context('eye'),
     tint: regl.prop('tint'),
-    envMap: teapotFBO.color[0],
+    envMap: teapotFBO,
     model: (context, {position}) => mat4.translate([], mat4.identity([]), position)
   }
 })

--- a/example/deferred_shading.js
+++ b/example/deferred_shading.js
@@ -151,8 +151,8 @@ const drawDirectionalLight = regl({
     position: [ -4, -4, 4, -4, 0, 4 ]
   },
   uniforms: {
-    albedoTex: () => fbo.color[0],
-    normalTex: () => fbo.color[1],
+    albedoTex: fbo.color[0],
+    normalTex: fbo.color[1],
     ambientLight: [0.3, 0.3, 0.3],
     diffuseLight: [0.7, 0.7, 0.7],
     lightDir: [0.39, 0.87, 0.29]
@@ -217,9 +217,9 @@ const drawPointLight = regl({
     gl_Position = pos;
   }`,
   uniforms: {
-    albedoTex: () => fbo.color[0],
-    normalTex: () => fbo.color[1],
-    positionTex: () => fbo.color[2],
+    albedoTex: fbo.color[0],
+    normalTex: fbo.color[1],
+    positionTex: fbo.color[2],
     ambientLight: regl.prop('ambientLight'),
     diffuseLight: regl.prop('diffuseLight'),
     lightPosition: regl.prop('translate'),

--- a/example/graph.js
+++ b/example/graph.js
@@ -172,7 +172,7 @@ const blurPass = regl({
   },
   uniforms: {
     src: (context, props) => {
-      return props.src.color[0]
+      return props.src
     },
     axis: (context, props) => {
       let result = [0, 0]
@@ -347,7 +347,7 @@ const renderPoints = regl({
     id: VERTEX_ID_BUFFER
   },
   uniforms: {
-    vertexState: ({tick}) => VERTEX_STATE[tick % 2].color[0]
+    vertexState: ({tick}) => VERTEX_STATE[tick % 2]
   },
   depth: {enable: false, mask: false},
   primitive: 'points',
@@ -389,7 +389,7 @@ const renderEdges = regl({
     arcDir: ARCS.map((arc, i) => i % 2)
   },
   uniforms: {
-    vertexState: ({tick}) => VERTEX_STATE[tick % 2].color[0],
+    vertexState: ({tick}) => VERTEX_STATE[tick % 2],
     dir: regl.prop('dir')
   },
   depth: {enable: false, mask: false},
@@ -431,7 +431,7 @@ function step ({tick}) {
     regl.clear({ color: [0, 0, 0, 1] })
     splatMouse()
     splatVerts({
-      vertexState: VERTEX_STATE[(tick + 1) % 2].color[0]
+      vertexState: VERTEX_STATE[(tick + 1) % 2]
     })
   })
   for (let i = 0; i < 2 * BLUR_PASSES; ++i) {
@@ -443,16 +443,16 @@ function step ({tick}) {
   }
   gradPass({
     dest: FIELDS[1],
-    src: FIELDS[0].color[0]
+    src: FIELDS[0]
   })
   applySpringForces({
     dest: VERTEX_STATE[(tick + 1) % 2],
-    src: VERTEX_STATE[tick % 2].color[0]
+    src: VERTEX_STATE[tick % 2]
   })
   integrateVerts({
     dest: VERTEX_STATE[tick % 2],
-    src: VERTEX_STATE[(tick + 1) % 2].color[0],
-    field: FIELDS[1].color[0]
+    src: VERTEX_STATE[(tick + 1) % 2],
+    field: FIELDS[1]
   })
 }
 

--- a/example/life.js
+++ b/example/life.js
@@ -60,7 +60,7 @@ const setupQuad = regl({
   },
 
   uniforms: {
-    prevState: ({tick}) => state[tick % 2].color[0]
+    prevState: ({tick}) => state[tick % 2]
   },
 
   depth: { enable: false },

--- a/example/point-light-shadow.js
+++ b/example/point-light-shadow.js
@@ -151,7 +151,7 @@ const drawNormal = regl({
                        viewportWidth / viewportHeight,
                        0.01,
                        1000),
-    shadowCube: shadowFbo.color[0]
+    shadowCube: shadowFbo
   },
   frag: `
   precision mediump float;

--- a/example/shadow_map.js
+++ b/example/shadow_map.js
@@ -118,7 +118,7 @@ const drawNormal = regl({
                        viewportWidth / viewportHeight,
                        0.01,
                        2000),
-    shadowMap: () => fbo.color[0],
+    shadowMap: fbo,
     minBias: () => 0.005,
     maxBias: () => 0.03
   },

--- a/lib/core.js
+++ b/lib/core.js
@@ -1604,13 +1604,23 @@ module.exports = function reglCore (
         result = createStaticDecl(function () {
           return value
         })
-      } else if (
-        typeof value === 'function' &&
-        (value._reglType === 'texture2d' ||
-         value._reglType === 'textureCube')) {
-        result = createStaticDecl(function (env) {
-          return env.link(value)
-        })
+      } else if (typeof value === 'function') {
+        var reglType = value._reglType
+        if (reglType === 'texture2d' ||
+            reglType === 'textureCube') {
+          result = createStaticDecl(function (env) {
+            return env.link(value)
+          })
+        } else if (reglType === 'framebuffer' ||
+                   reglType === 'framebufferCube') {
+          check(value.color.length > 0,
+            'missing color attachment for framebuffer sent to uniform "' + name + '"')
+          result = createStaticDecl(function (env) {
+            return env.link(value.color[0])
+          })
+        } else {
+          check.raise('invalid data for uniform "' + name + '"')
+        }
       } else if (isArrayLike(value)) {
         result = createStaticDecl(function (env) {
           var ITEM = env.global.def('[',
@@ -1624,7 +1634,7 @@ module.exports = function reglCore (
           return ITEM
         })
       } else {
-        check.commandRaise('invalid uniform ' + name)
+        check.commandRaise('invalid or missing data for uniform "' + name + '"')
       }
       result.value = value
       UNIFORMS[name] = result
@@ -2309,6 +2319,9 @@ module.exports = function reglCore (
         }
         if (isStatic(arg)) {
           var value = arg.value
+          check.command(
+            value !== null && typeof value !== 'undefined',
+            'missing uniform "' + name + '"')
           if (type === GL_SAMPLER_2D || type === GL_SAMPLER_CUBE) {
             check.command(
               typeof value === 'function' &&
@@ -2426,25 +2439,43 @@ module.exports = function reglCore (
         VALUE = scope.def(shared.uniforms, '[', stringStore.id(name), ']')
       }
 
+      if (type === GL_SAMPLER_2D) {
+        scope(
+          'if(', VALUE, '&&', VALUE, '._reglType==="framebuffer"){',
+          VALUE, '=', VALUE, '.color[0];',
+          '}')
+      } else if (type === GL_SAMPLER_CUBE) {
+        scope(
+          'if(', VALUE, '&&', VALUE, '._reglType==="framebufferCube"){',
+          VALUE, '=', VALUE, '.color[0];',
+          '}')
+      }
+
       // perform type validation
       check.optional(function () {
-        function check (pred) {
-          env.assert(scope, pred, 'invalid or missing uniform "' + name + '"')
+        function check (pred, message) {
+          env.assert(scope, pred,
+            'bad data for uniform "' + name + '".  ' + message)
         }
 
         function checkType (type) {
-          check('typeof ' + VALUE + '==="' + type + '"')
+          check(
+            'typeof ' + VALUE + '==="' + type + '"',
+            'invalid type, expected ' + type)
         }
 
         function checkVector (n, type) {
-          check(shared.isArrayLike + '(' + VALUE + ')&&' + VALUE + '.length===' + n)
+          check(
+            shared.isArrayLike + '(' + VALUE + ')&&' + VALUE + '.length===' + n,
+            'invalid vector, should have length ' + n)
         }
 
         function checkTexture (target) {
           check(
             'typeof ' + VALUE + '==="function"&&' +
             VALUE + '._reglType==="texture' +
-            (target === GL_TEXTURE_2D ? '2d' : 'Cube') + '"')
+            (target === GL_TEXTURE_2D ? '2d' : 'Cube') + '"',
+            'invalid texture type')
         }
 
         switch (type) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -2325,10 +2325,14 @@ module.exports = function reglCore (
           if (type === GL_SAMPLER_2D || type === GL_SAMPLER_CUBE) {
             check.command(
               typeof value === 'function' &&
-              ((value._reglType === 'texture2d' && type === GL_SAMPLER_2D) ||
-              (value._reglType === 'textureCube' && type === GL_SAMPLER_CUBE)),
+              ((type === GL_SAMPLER_2D &&
+                (value._reglType === 'texture2d' ||
+                value._reglType === 'framebuffer')) ||
+              (type === GL_SAMPLER_CUBE &&
+                (value._reglType === 'textureCube' ||
+                value._reglType === 'framebufferCube'))),
               'invalid texture for uniform ' + name)
-            var TEX_VALUE = env.link(value._texture)
+            var TEX_VALUE = env.link(value._texture || value.color[0]._texture)
             scope(GL, '.uniform1i(', LOCATION, ',', TEX_VALUE + '.bind());')
             scope.exit(TEX_VALUE, '.unbind();')
           } else if (


### PR DESCRIPTION
Support directly passing framebuffer objects into texture uniforms.  This makes using framebuffer objects in ping-pong a bit less verbose.  The `.color` array can still be accessed for multiple render targets.