### PR TITLE
Browser test perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "runscript": "^1.1.0",
     "snazzy": "^3.0.0",
     "standard": "^6.0.7",
-    "tap-browser-color": "^0.1.2",
     "tape": "^4.4.0",
     "teapot": "^1.0.0",
     "three": "^0.79.0",

--- a/test/util/browser.js
+++ b/test/util/browser.js
@@ -1,2 +1,45 @@
-require('tap-browser-color')()
+var colors = {
+  PENDING: '#FCD62A',
+  FAILING: '#F28E82',
+  PASSING: '#8ECA6C'
+}
+
+var originalLog = console.log
+var container = document.body.appendChild(document.createElement('pre'))
+
+var failed = 0
+var passed = 0
+
+function updateStyle () {
+  var s = document.body.style
+  if (failed > 0) {
+    if (s.backgroundColor !== colors.FAILING) {
+      s.backgroundColor = colors.FAILING
+    }
+  } else if (passed > 0 && failed === 0) {
+    if (s.backgroundColor !== colors.PASSING) {
+      s.backgroundColor = colors.PASSING
+    }
+  } else {
+    if (s.backgroundColor !== colors.PENDING) {
+      s.backgroundColor = colors.PENDING
+    }
+  }
+}
+
+console.log = function (line) {
+  if (typeof line !== 'string') {
+    line = line + ''
+  }
+  if (line.indexOf('ok') === 0) {
+    passed += 1
+  } else if (line.indexOf('not ok') === 0) {
+    failed += 1
+  }
+  updateStyle()
+  originalLog.apply(console, arguments)
+  container.appendChild(document.createTextNode(line + '\n'))
+}
+
+updateStyle()
 require('./index')

--- a/test/util/browser.js
+++ b/test/util/browser.js
@@ -1,8 +1,6 @@
-var colors = {
-  PENDING: '#FCD62A',
-  FAILING: '#F28E82',
-  PASSING: '#8ECA6C'
-}
+var PENDING = '#FCD62A'
+var FAILING = '#F28E82'
+var PASSING = '#8ECA6C'
 
 var originalLog = console.log
 var container = document.body.appendChild(document.createElement('pre'))
@@ -10,22 +8,10 @@ var container = document.body.appendChild(document.createElement('pre'))
 var failed = 0
 var passed = 0
 
-function updateStyle () {
-  var s = document.body.style
-  if (failed > 0) {
-    if (s.backgroundColor !== colors.FAILING) {
-      s.backgroundColor = colors.FAILING
-    }
-  } else if (passed > 0 && failed === 0) {
-    if (s.backgroundColor !== colors.PASSING) {
-      s.backgroundColor = colors.PASSING
-    }
-  } else {
-    if (s.backgroundColor !== colors.PENDING) {
-      s.backgroundColor = colors.PENDING
-    }
-  }
-}
+document.body.style.backgroundColor = PENDING
+
+var pendingLines = []
+var pendingRaf = null
 
 console.log = function (line) {
   if (typeof line !== 'string') {
@@ -36,10 +22,28 @@ console.log = function (line) {
   } else if (line.indexOf('not ok') === 0) {
     failed += 1
   }
-  updateStyle()
+  pendingLines.push(line)
   originalLog.apply(console, arguments)
-  container.appendChild(document.createTextNode(line + '\n'))
+
+  if (!pendingRaf) {
+    pendingRaf = window.requestAnimationFrame(updateDOM)
+  }
 }
 
-updateStyle()
+function updateDOM () {
+  var s = document.body.style
+  if (failed > 0) {
+    if (s.backgroundColor !== FAILING) {
+      s.backgroundColor = FAILING
+    }
+  } else if (passed > 0 && failed === 0) {
+    if (s.backgroundColor !== PASSING) {
+      s.backgroundColor = PASSING
+    }
+  }
+  container.appendChild(document.createTextNode(pendingLines.join('\n') + '\n'))
+  pendingLines.length = 0
+  pendingRaf = null
+}
+
 require('./index')


### PR DESCRIPTION
This PR removes the tap-browser-color dependency and replaces it with a more efficient browser update scheme.  Now the browser tests complete in about the same amount of time as the headless version.

Fixes #177 