### PR TITLE
Improve stencil test cases

### DIFF
--- a/test/stencil.js
+++ b/test/stencil.js
@@ -94,7 +94,7 @@ tape('stencil', function (t) {
       mask: 0xff,
       opFront: {
         fail: 'keep',
-        zfail: 'keep',
+        zfail: 'replace',
         pass: 'keep'
       },
       opBack: {
@@ -123,6 +123,30 @@ tape('stencil', function (t) {
       }
     }
   ]
+
+  // we need to make sure that we test for all possible values of cmp.
+  Object.keys(compareFuncs).forEach(function (cmp) {
+    permutations.push({
+      enable: true,
+      func: {
+        cmp: cmp,
+        ref: 0,
+        mask: 0xff
+      },
+      mask: 0xff,
+      opFront: {
+        fail: 'keep',
+        zfail: 'keep',
+        pass: 'keep'
+      },
+      opBack: {
+        fail: 'keep',
+        zfail: 'keep',
+        pass: 'keep'
+      }
+    }
+    )
+  })
 
   var staticOptions = {
     frag: [
@@ -165,22 +189,22 @@ tape('stencil', function (t) {
     }
   }, staticOptions))
 
-  permutations.forEach(function (params) {
+  permutations.forEach(function (params, i) {
     dynamicDraw(params)
-    testFlags('dynamic 1-shot - ', params)
+    testFlags('dynamic 1-shot - #' + i + ' - x', params)
   })
 
-  permutations.forEach(function (params) {
+  permutations.forEach(function (params, i) {
     dynamicDraw([params])
-    testFlags('batch - ', params)
+    testFlags('batch - #' + i + ' - x', params)
   })
 
-  permutations.forEach(function (params) {
+  permutations.forEach(function (params, i) {
     var staticDraw = regl(extend({
       stencil: params
     }, staticOptions))
     staticDraw()
-    testFlags('static - ', params)
+    testFlags('static - #' + i + ' - x', params)
   })
 
   regl.destroy()

--- a/test/stencil.js
+++ b/test/stencil.js
@@ -207,6 +207,40 @@ tape('stencil', function (t) {
     testFlags('static - #' + i + ' - x', params)
   })
 
+  // now test nested dynamic properties:
+
+  var nestedDynamicDraw = regl(extend({
+    stencil: {
+      enable: regl.prop('enable'),
+      func: {
+        cmp: regl.prop('func.cmp'),
+        ref: regl.prop('func.ref'),
+        mask: regl.prop('func.mask')
+      },
+      mask: regl.prop('mask'),
+      opFront: {
+        fail: regl.prop('opFront.fail'),
+        zfail: regl.prop('opFront.zfail'),
+        pass: regl.prop('opFront.pass')
+      },
+      opBack: {
+        fail: regl.prop('opBack.fail'),
+        zfail: regl.prop('opBack.zfail'),
+        pass: regl.prop('opBack.pass')
+      }
+    }
+  }, staticOptions))
+
+  permutations.forEach(function (params, i) {
+    nestedDynamicDraw(params)
+    testFlags('nested dynamic 1-shot - #' + i + ' - x', params)
+  })
+
+  permutations.forEach(function (params, i) {
+    nestedDynamicDraw([params])
+    testFlags('nested batch - #' + i + ' - x', params)
+  })
+
   regl.destroy()
   t.equals(gl.getError(), 0, 'error ok')
   createContext.destroy(gl)


### PR DESCRIPTION
This improves the cases for the stencil buffer:

* Test for all possible values of `func.cmp`
* Test for dynamic properties in nested state. As part of solving issue #208