### PR TITLE
Lint all markdown files

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,15 @@
+{
+  "plugins": {
+    "remark-lint": {
+      "no-multiple-toplevel-headings": false,
+      "list-item-indent": false,
+      "maximum-line-length": 10000,
+      "table-pipe-alignment": false,
+      "table-cell-padding": false
+    },
+    "remark-validate-links": {
+    },
+    "remark-toc": {
+    }
+  }
+}

--- a/API.md
+++ b/API.md
@@ -2,7 +2,160 @@
 
 ## Table of contents
 
----------------------------------------
+-   [Initialization](#initialization)
+
+    -   [Quick start](#quick-start)
+
+        -   [As a fullscreen canvas](#as-a-fullscreen-canvas)
+        -   [From a container div](#from-a-container-div)
+        -   [From a canvas](#from-a-canvas)
+        -   [From a WebGL context](#from-a-webgl-context)
+        -   [From a headless context](#from-a-headless-context)
+
+    -   [All initialization options](#all-initialization-options)
+
+-   [Commands](#commands)
+
+    -   [Executing commands](#executing-commands)
+
+        -   [One-shot rendering](#one-shot-rendering)
+        -   [Batch rendering](#batch-rendering)
+        -   [Scoped commands](#scoped-commands)
+
+    -   [Inputs](#inputs)
+
+        -   [Example](#example)
+        -   [Context](#context)
+        -   [Props](#props)
+        -   [this](#this)
+
+    -   [Parameters](#parameters)
+
+        -   [Shaders](#shaders)
+        -   [Uniforms](#uniforms)
+        -   [Attributes](#attributes)
+        -   [Drawing](#drawing)
+        -   [Render target](#render-target)
+        -   [Profiling](#profiling)
+        -   [Depth buffer](#depth-buffer)
+        -   [Blending](#blending)
+        -   [Stencil](#stencil)
+        -   [Polygon offset](#polygon-offset)
+        -   [Culling](#culling)
+        -   [Front face](#front-face)
+        -   [Dithering](#dithering)
+        -   [Line width](#line-width)
+        -   [Color mask](#color-mask)
+        -   [Sample coverage](#sample-coverage)
+        -   [Scissor](#scissor)
+        -   [Viewport](#viewport)
+
+-   [Resources](#resources)
+
+    -   [Buffers](#buffers)
+
+        -   [Buffer constructor](#buffer-constructor)
+
+        -   [Buffer update](#buffer-update)
+
+            -   [Buffer subdata](#buffer-subdata)
+
+        -   [Buffer destructor](#buffer-destructor)
+
+        -   [Profiling info](#profiling-info)
+
+    -   [Elements](#elements)
+
+        -   [Element constructor](#element-constructor)
+
+        -   [Element update](#element-update)
+
+            -   [Element subdata](#element-subdata)
+
+        -   [Element destructor](#element-destructor)
+
+    -   [Textures](#textures)
+
+        -   [Texture constructor](#texture-constructor)
+
+        -   [Texture update](#texture-update)
+
+            -   [Texture subimage](#texture-subimage)
+            -   [Texture resize](#texture-resize)
+
+        -   [Texture destructor](#texture-destructor)
+
+        -   [Texture profiling](#texture-profiling)
+
+    -   [Cube maps](#cube-maps)
+
+        -   [Cube map constructor](#cube-map-constructor)
+
+        -   [Cube map update](#cube-map-update)
+
+            -   [Cube map subimage](#cube-map-subimage)
+
+        -   [Cube map resize](#cube-map-resize)
+
+        -   [Cube map profiling](#cube-map-profiling)
+
+        -   [Cube map destructor](#cube-map-destructor)
+
+    -   [Renderbuffers](#renderbuffers)
+
+        -   [Renderbuffer constructor](#renderbuffer-constructor)
+
+        -   [Renderbuffer update](#renderbuffer-update)
+
+            -   [Renderbuffer resize](#renderbuffer-resize)
+
+        -   [Renderbuffers destructor](#renderbuffers-destructor)
+
+        -   [Renderbuffer profiling](#renderbuffer-profiling)
+
+    -   [Framebuffers](#framebuffers)
+
+        -   [Framebuffer constructor](#framebuffer-constructor)
+
+        -   [Framebuffer update](#framebuffer-update)
+
+            -   [Framebuffer resize](#framebuffer-resize)
+
+        -   [Framebuffer destructor](#framebuffer-destructor)
+
+    -   [Cubic frame buffers](#cubic-frame-buffers)
+
+        -   [Cube framebuffer constructor](#cube-framebuffer-constructor)
+
+        -   [Cube framebuffer update](#cube-framebuffer-update)
+
+            -   [Cube framebuffer resize](#cube-framebuffer-resize)
+
+        -   [Cube framebuffer destructor](#cube-framebuffer-destructor)
+
+-   [Other tasks](#other-tasks)
+
+    -   [Clear the draw buffer](#clear-the-draw-buffer)
+    -   [Reading pixels](#reading-pixels)
+    -   [Per-frame callbacks](#per-frame-callbacks)
+    -   [Extensions](#extensions)
+    -   [Device capabilities and limits](#device-capabilities-and-limits)
+    -   [Performance metrics](#performance-metrics)
+    -   [Clean up](#clean-up)
+    -   [Context loss](#context-loss)
+    -   [Unsafe escape hatch](#unsafe-escape-hatch)
+
+-   [Tips](#tips)
+
+    -   [Reuse commands](#reuse-commands)
+    -   [Reuse resources (buffers, elements, textures, etc.)](#reuse-resources-buffers-elements-textures-etc)
+    -   [Preallocate memory](#preallocate-memory)
+    -   [Debug vs release](#debug-vs-release)
+    -   [Profiling tips](#profiling-tips)
+    -   [Context loss mitigation](#context-loss-mitigation)
+    -   [Cameras](#cameras)
+    -   [Use batch mode](#use-batch-mode)
+    -   [Use glslify](#use-glslify)
 
 ## Initialization
 
@@ -71,29 +224,29 @@ var regl = require('regl')(require('gl')(256, 256))
 
 ### All initialization options
 
-| Options | Meaning |
-| ------- | ------- |
-| `gl` | A reference to a WebGL rendering context. (Default created from canvas) |
-| `canvas` | A reference to an HTML canvas element. (Default created and appending to container) |
-| `container` | A container element which regl inserts a canvas into. (Default `document.body`) |
-| `attributes` | The [context creation attributes](https://www.khronos.org/registry/webgl/specs/1.0/#WEBGLCONTEXTATTRIBUTES) passed to the WebGL context constructor.  See below for defaults. |
-| `pixelRatio` | A multiplier which is used to scale the canvas size relative to the container.  (Default `window.devicePixelRatio`)|
-| `extensions` | A list of extensions that must be supported by WebGL context. Default `[]` |
-| `optionalExtensions` | A list of extensions which are loaded opportunistically. Default `[]` |
-| `profile` | If set, turns on profiling for all commands by default. (Default `false`) |
-| `onDone` | An optional callback which accepts a pair of arguments, `(err, regl)` that is called after the application loads.  If not specified, context creation errors throw. |
+| Options              | Meaning                                                                                                                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gl`                 | A reference to a WebGL rendering context. (Default created from canvas)                                                                                                       |
+| `canvas`             | A reference to an HTML canvas element. (Default created and appending to container)                                                                                           |
+| `container`          | A container element which regl inserts a canvas into. (Default `document.body`)                                                                                               |
+| `attributes`         | The [context creation attributes](https://www.khronos.org/registry/webgl/specs/1.0/#WEBGLCONTEXTATTRIBUTES) passed to the WebGL context constructor.  See below for defaults. |
+| `pixelRatio`         | A multiplier which is used to scale the canvas size relative to the container.  (Default `window.devicePixelRatio`)                                                           |
+| `extensions`         | A list of extensions that must be supported by WebGL context. Default `[]`                                                                                                    |
+| `optionalExtensions` | A list of extensions which are loaded opportunistically. Default `[]`                                                                                                         |
+| `profile`            | If set, turns on profiling for all commands by default. (Default `false`)                                                                                                     |
+| `onDone`             | An optional callback which accepts a pair of arguments, `(err, regl)` that is called after the application loads.  If not specified, context creation errors throw.           |
 
 **Notes**
 
-* `canvas` or `container` may be a CSS selector string or a DOM element
-* `extensions` and `optionalExtensions` can be either arrays or comma separated strings representing all extensions.  For more information see the [WebGL extension registry](https://www.khronos.org/registry/webgl/extensions/)
-* `onDone` is called
+-   `canvas` or `container` may be a CSS selector string or a DOM element
+-   `extensions` and `optionalExtensions` can be either arrays or comma separated strings representing all extensions.  For more information see the [WebGL extension registry](https://www.khronos.org/registry/webgl/extensions/)
+-   `onDone` is called
 
----------------------------------------
+* * *
 
 ## Commands
 
-*Draw commands* are the fundamental abstraction in `regl`.  A draw command wraps up all of the WebGL state associated with a draw call (either `drawArrays` or `drawElements`) and packages it into a single reusable function. For example, here is a command that draws a triangle,
+_Draw commands_ are the fundamental abstraction in `regl`.  A draw command wraps up all of the WebGL state associated with a draw call (either `drawArrays` or `drawElements`) and packages it into a single reusable function. For example, here is a command that draws a triangle,
 
 ```javascript
 const drawTriangle = regl({
@@ -122,7 +275,7 @@ To run a command you call it just like you would any function,
 drawTriangle()
 ```
 
----------------------------------------
+* * *
 
 ### Executing commands
 
@@ -166,15 +319,15 @@ command(props, function (context) {
 })
 ```
 
----------------------------------------
+* * *
 
 ### Inputs
 
 Inputs to `regl` commands can come from one of three sources,
 
-* Context: Context variables are not used directly in commands, but can be passed into
-* Props: props are arguments which are passed into commands
-* `this`: `this` variables are indexed from the `this` variable that the command was called with
+-   Context: Context variables are not used directly in commands, but can be passed into
+-   Props: props are arguments which are passed into commands
+-   `this`: `this` variables are indexed from the `this` variable that the command was called with
 
 If you are familiar with Facebook's [react](https://github.com/facebook/react), these are roughly analogous to a component's [context](https://facebook.github.io/react/docs/context.html), [props](https://facebook.github.io/react/docs/transferring-props.html) and [state](https://facebook.github.io/react/docs/component-api.html#setstate) variables respectively.
 
@@ -273,17 +426,17 @@ drawSpinningStretchyTriangle([
 
 Context variables in `regl` are computed before any other parameters and can also be passed from a scoped command to any sub-commands.  `regl` defines the following default context variables:
 
-| Name | Description |
-|------|-------------|
-| `tick` | The number of frames rendered |
-| `time` | Total time elapsed since the regl was initialized in seconds |
-| `viewportWidth` | Width of the current viewport in pixels |
-| `viewportHeight` | Height of the current viewport in pixels |
-| `framebufferWidth` | Width of the current framebuffer in pixels |
-| `framebufferHeight` | Height of the current framebuffer in pixels |
-| `drawingBufferWidth` | Width of the WebGL context drawing buffer |
-| `drawingBufferHeight` | Height of the WebGL context drawing buffer |
-| `pixelRatio` | The pixel ratio of the drawing buffer |
+| Name                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `tick`                | The number of frames rendered                                |
+| `time`                | Total time elapsed since the regl was initialized in seconds |
+| `viewportWidth`       | Width of the current viewport in pixels                      |
+| `viewportHeight`      | Height of the current viewport in pixels                     |
+| `framebufferWidth`    | Width of the current framebuffer in pixels                   |
+| `framebufferHeight`   | Height of the current framebuffer in pixels                  |
+| `drawingBufferWidth`  | Width of the WebGL context drawing buffer                    |
+| `drawingBufferHeight` | Height of the WebGL context drawing buffer                   |
+| `pixelRatio`          | The pixel ratio of the drawing buffer                        |
 
 You can define context variables in the `context` block of a command.  For example, here is how you can use context variables to set up a camera:
 
@@ -408,13 +561,13 @@ teapotMesh.draw({
 })
 ```
 
----------------------------------------
+* * *
 
 ### Parameters
 
 The input to a command declaration is a complete description of the WebGL state machine in the form of an object.  The properties of this object are parameters which specify how values in the WebGL state machine are to be computed.
 
----------------------------------------
+* * *
 
 #### Shaders
 
@@ -438,22 +591,22 @@ var command = regl({
 })
 ```
 
-| Property | Description |
-|----------|-------------|
-| `vert` | Source code of vertex shader |
-| `frag` | Source code of fragment shader |
+| Property | Description                    |
+| -------- | ------------------------------ |
+| `vert`   | Source code of vertex shader   |
+| `frag`   | Source code of fragment shader |
 
 **Related WebGL APIs**
 
-* [`gl.createShader`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateShader.xml)
-* [`gl.shaderSource`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glShaderSource.xml)
-* [`gl.compileShader`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompileShader.xml)
-* [`gl.createProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateProgram.xml)
-* [`gl.attachShader`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glAttachShader.xml)
-* [`gl.linkProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glLinkProgram.xml)
-* [`gl.useProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glUseProgram.xml)
+-   [`gl.createShader`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateShader.xml)
+-   [`gl.shaderSource`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glShaderSource.xml)
+-   [`gl.compileShader`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompileShader.xml)
+-   [`gl.createProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateProgram.xml)
+-   [`gl.attachShader`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glAttachShader.xml)
+-   [`gl.linkProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glLinkProgram.xml)
+-   [`gl.useProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glUseProgram.xml)
 
----------------------------------------
+* * *
 
 #### Uniforms
 
@@ -488,15 +641,15 @@ var command = regl({
 
 **Notes**
 
-* To specify uniforms in nested structs use the fully qualified path with dot notation
-* Matrix uniforms are specified as flat length n^2 arrays without transposing
+-   To specify uniforms in nested structs use the fully qualified path with dot notation
+-   Matrix uniforms are specified as flat length n^2 arrays without transposing
 
 **Related WebGL APIs**
 
-* [`gl.getUniformLocation`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetUniformLocation.xml)
-* [`gl.uniform`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glUniform.xml)
+-   [`gl.getUniformLocation`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetUniformLocation.xml)
+-   [`gl.uniform`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glUniform.xml)
 
----------------------------------------
+* * *
 
 #### Attributes
 
@@ -537,32 +690,32 @@ var command = regl({
 
 Each attribute can have any of the following optional properties,
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `buffer` | A `REGLBuffer` wrapping the buffer object | `null` |
-| `offset` | The offset of the `vertexAttribPointer` in bytes | `0` |
-| `stride` | The stride of the `vertexAttribPointer` in bytes | `0` |
-| `normalized` | Whether the pointer is normalized | `false` |
-| `size` | The size of the vertex attribute | Inferred from shader |
-| `divisor` | Sets `gl.vertexAttribDivisorANGLE` | `0` * |
+| Property     | Description                                      | Default              |
+| ------------ | ------------------------------------------------ | -------------------- |
+| `buffer`     | A `REGLBuffer` wrapping the buffer object        | `null`               |
+| `offset`     | The offset of the `vertexAttribPointer` in bytes | `0`                  |
+| `stride`     | The stride of the `vertexAttribPointer` in bytes | `0`                  |
+| `normalized` | Whether the pointer is normalized                | `false`              |
+| `size`       | The size of the vertex attribute                 | Inferred from shader |
+| `divisor`    | Sets `gl.vertexAttribDivisorANGLE`               | `0` \*               |
 
 **Notes**
 
-* Attribute size is inferred from the shader vertex attribute if not specified
-* If a buffer is passed for an attribute then all pointer info is inferred
-* If the arguments to `regl.buffer` are passed, then a buffer is constructed
-* If an array is passed to an attribute, then the vertex attribute is set to a constant
-* `divisor` is only supported if the `ANGLE_instanced_arrays` extension is available
+-   Attribute size is inferred from the shader vertex attribute if not specified
+-   If a buffer is passed for an attribute then all pointer info is inferred
+-   If the arguments to `regl.buffer` are passed, then a buffer is constructed
+-   If an array is passed to an attribute, then the vertex attribute is set to a constant
+-   `divisor` is only supported if the `ANGLE_instanced_arrays` extension is available
 
 **Related WebGL APIs**
 
-* [`gl.vertexAttribPointer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttribPointer.xml)
-* [`gl.vertexAttrib`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttrib.xml)
-* [`gl.getAttribLocation`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetAttribLocation.xml)
-* [`gl.vertexAttibDivisor`](https://www.opengl.org/sdk/docs/man4/html/glVertexAttribDivisor.xhtml)
-* [`gl.enableVertexAttribArray`, `gl.disableVertexAttribArray`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDisableVertexAttribArray.xml)
+-   [`gl.vertexAttribPointer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttribPointer.xml)
+-   [`gl.vertexAttrib`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glVertexAttrib.xml)
+-   [`gl.getAttribLocation`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetAttribLocation.xml)
+-   [`gl.vertexAttibDivisor`](https://www.opengl.org/sdk/docs/man4/html/glVertexAttribDivisor.xhtml)
+-   [`gl.enableVertexAttribArray`, `gl.disableVertexAttribArray`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDisableVertexAttribArray.xml)
 
----------------------------------------
+* * *
 
 #### Drawing
 
@@ -576,39 +729,39 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `primitive` | Sets the primitive type | `'triangles'` * |
-| `count` | Number of vertices to draw | `0` * |
-| `offset` | Offset of primitives to draw | `0` |
-| `instances` | Number of instances to render | `0` ** |
-| `elements` | Element array buffer | `null` |
+| Property    | Description                   | Default          |
+| ----------- | ----------------------------- | ---------------- |
+| `primitive` | Sets the primitive type       | `'triangles'` \* |
+| `count`     | Number of vertices to draw    | `0` \*           |
+| `offset`    | Offset of primitives to draw  | `0`              |
+| `instances` | Number of instances to render | `0` \*\*         |
+| `elements`  | Element array buffer          | `null`           |
 
 **Notes**
 
-* If `elements` is specified while `primitive`, `count` and `offset` are not, then these values may be inferred from the state of the element array buffer.
-* `elements` must be either an instance of `regl.elements` or else the arguments to `regl.elements`
-* `instances` is only applicable if the `ANGLE_instanced_arrays` extension is present.
-* `primitive` can take on the following values
+-   If `elements` is specified while `primitive`, `count` and `offset` are not, then these values may be inferred from the state of the element array buffer.
+-   `elements` must be either an instance of `regl.elements` or else the arguments to `regl.elements`
+-   `instances` is only applicable if the `ANGLE_instanced_arrays` extension is present.
+-   `primitive` can take on the following values
 
-| Primitive type | Description |
-|-------|-------------|
-| `'points'` | `gl.POINTS` |
-| `'lines'` | `gl.LINES` |
-| `'line strip'` | `gl.LINE_STRIP` |
-| `'line loop` | `gl.LINE_LOOP` |
-| `'triangles` | `gl.TRIANGLES` |
+| Primitive type     | Description         |
+| ------------------ | ------------------- |
+| `'points'`         | `gl.POINTS`         |
+| `'lines'`          | `gl.LINES`          |
+| `'line strip'`     | `gl.LINE_STRIP`     |
+| `'line loop`       | `gl.LINE_LOOP`      |
+| `'triangles`       | `gl.TRIANGLES`      |
 | `'triangle strip'` | `gl.TRIANGLE_STRIP` |
-| `'triangle fan'` | `gl.TRIANGLE_FAN` |
+| `'triangle fan'`   | `gl.TRIANGLE_FAN`   |
 
 **Related WebGL APIs**
 
-* [`gl.drawArrays`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawArrays.xml)
-* [`gl.drawElements`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawElements.xml)
-* [`gl.drawArraysInstancedANGLE`](https://www.opengl.org/sdk/docs/man4/html/glDrawArraysInstanced.xhtml)
-* [`gl.drawElementsInstancedANGLE`](https://www.opengl.org/sdk/docs/man4/html/glDrawElementsInstanced.xhtml)
+-   [`gl.drawArrays`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawArrays.xml)
+-   [`gl.drawElements`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawElements.xml)
+-   [`gl.drawArraysInstancedANGLE`](https://www.opengl.org/sdk/docs/man4/html/glDrawArraysInstanced.xhtml)
+-   [`gl.drawElementsInstancedANGLE`](https://www.opengl.org/sdk/docs/man4/html/glDrawElementsInstanced.xhtml)
 
----------------------------------------
+* * *
 
 #### Render target
 
@@ -622,15 +775,15 @@ var command = regl({
 
 **Notes**
 
-* `framebuffer` must be a `regl.framebuffer` object
-* Passing `null` sets the framebuffer to the drawing buffer
-* Updating the render target will modify the viewport
+-   `framebuffer` must be a `regl.framebuffer` object
+-   Passing `null` sets the framebuffer to the drawing buffer
+-   Updating the render target will modify the viewport
 
 **Related WebGL APIs**
 
-* [`gl.bindFramebuffer`](https://www.opengl.org/sdk/docs/man4/html/glBindFramebuffer.xhtml)
+-   [`gl.bindFramebuffer`](https://www.opengl.org/sdk/docs/man4/html/glBindFramebuffer.xhtml)
 
----------------------------------------
+* * *
 
 #### Profiling
 
@@ -657,22 +810,22 @@ regl.frame(function () {
 
 The following stats are tracked for each command in the `.stats` property:
 
-| Statistic | Meaning |
-|-----------|---------|
-| `count` | The number of times the command has been called |
-| `cpuTime` | The cumulative CPU time spent executing the command in milliseconds |
+| Statistic | Meaning                                                                                                                                                                                              |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `count`   | The number of times the command has been called                                                                                                                                                      |
+| `cpuTime` | The cumulative CPU time spent executing the command in milliseconds                                                                                                                                  |
 | `gpuTime` | The cumulative GPU time spent executing the command in milliseconds (requires the [EXT_disjoint_timer_query](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/) extension) |
 
 **Notes**
 
-* GPU timer queries update asynchronously.  If you are not using `regl.frame()` to tick your application, then you should periodically call `regl.poll()` each frame to update the timer statistics.
-* CPU time uses `performance.now` if available, otherwise it falls back to `Date.now`
+-   GPU timer queries update asynchronously.  If you are not using `regl.frame()` to tick your application, then you should periodically call `regl.poll()` each frame to update the timer statistics.
+-   CPU time uses `performance.now` if available, otherwise it falls back to `Date.now`
 
 **Related WebGL APIs**
 
-* [EXT_disjoint_timer_query](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/)
+-   [EXT_disjoint_timer_query](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/)
 
----------------------------------------
+* * *
 
 #### Depth buffer
 
@@ -693,35 +846,35 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `enable` | Toggles `gl.enable(gl.DEPTH_TEST)` | `true` |
-| `mask` | Sets `gl.depthMask` | `true` |
-| `range` | Sets `gl.depthRange` | `[0, 1]` |
-| `func` | Sets `gl.depthFunc`. See table below for possible values | `'less'` |
+| Property | Description                                              | Default  |
+| -------- | -------------------------------------------------------- | -------- |
+| `enable` | Toggles `gl.enable(gl.DEPTH_TEST)`                       | `true`   |
+| `mask`   | Sets `gl.depthMask`                                      | `true`   |
+| `range`  | Sets `gl.depthRange`                                     | `[0, 1]` |
+| `func`   | Sets `gl.depthFunc`. See table below for possible values | `'less'` |
 
 **Notes**
 
-* `depth.func` can take on the possible values
+-   `depth.func` can take on the possible values
 
-| Value | Description |
-|-------|-------------|
-| `'never'` | `gl.NEVER` |
-| `'always'` | `gl.ALWAYS` |
-| `'<', 'less'` | `gl.LESS` |
-| `'<=', 'lequal'` | `gl.LEQUAL` |
-| `'>', 'greater'` | `gl.GREATER` |
-| `'>=', 'gequal'` | `gl.GEQUAL` |
-| `'=', 'equal'` | `gl.EQUAL` |
+| Value              | Description   |
+| ------------------ | ------------- |
+| `'never'`          | `gl.NEVER`    |
+| `'always'`         | `gl.ALWAYS`   |
+| `'<', 'less'`      | `gl.LESS`     |
+| `'<=', 'lequal'`   | `gl.LEQUAL`   |
+| `'>', 'greater'`   | `gl.GREATER`  |
+| `'>=', 'gequal'`   | `gl.GEQUAL`   |
+| `'=', 'equal'`     | `gl.EQUAL`    |
 | `'!=', 'notequal'` | `gl.NOTEQUAL` |
 
 **Related WebGL APIs**
 
-* [`gl.depthFunc`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthFunc.xml)
-* [`gl.depthMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthMask.xml)
-* [`gl.depthRange`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthRangef.xml)
+-   [`gl.depthFunc`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthFunc.xml)
+-   [`gl.depthMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthMask.xml)
+-   [`gl.depthRange`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthRangef.xml)
 
----------------------------------------
+* * *
 
 #### Blending
 
@@ -750,55 +903,55 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `enable` | Toggles `gl.enable(gl.BLEND)` | `false` |
-| `equation` | Sets `gl.blendEquation` (see table) | `'add'` |
-| `func` | Sets `gl.blendFunc` (see table) | `{src:'src alpha',dst:'one minus src alpha'}` |
-| `color` | Sets `gl.blendColor` | `[0, 0, 0, 0]` |
+| Property   | Description                         | Default                                       |
+| ---------- | ----------------------------------- | --------------------------------------------- |
+| `enable`   | Toggles `gl.enable(gl.BLEND)`       | `false`                                       |
+| `equation` | Sets `gl.blendEquation` (see table) | `'add'`                                       |
+| `func`     | Sets `gl.blendFunc` (see table)     | `{src:'src alpha',dst:'one minus src alpha'}` |
+| `color`    | Sets `gl.blendColor`                | `[0, 0, 0, 0]`                                |
 
 **Notes**
 
-* `equation` can be either a string or an object with the fields `{rgb, alpha}`.  The former corresponds to `gl.blendEquation` and the latter to `gl.blendEquationSeparate`
-* The fields of `equation` can take on the following values
+-   `equation` can be either a string or an object with the fields `{rgb, alpha}`.  The former corresponds to `gl.blendEquation` and the latter to `gl.blendEquationSeparate`
+-   The fields of `equation` can take on the following values
 
-| Equation | Description |
-|----------|---------------|
-| `'add'` | `gl.FUNC_ADD` |
-| `'subtract'` | `gl.FUNC_SUBTRACT` |
+| Equation             | Description                |
+| -------------------- | -------------------------- |
+| `'add'`              | `gl.FUNC_ADD`              |
+| `'subtract'`         | `gl.FUNC_SUBTRACT`         |
 | `'reverse subtract'` | `gl.FUNC_REVERSE_SUBTRACT` |
-| `'min'` | `gl.MIN_EXT` |
-| `'max'` | `gl.MAX_EXT` |
+| `'min'`              | `gl.MIN_EXT`               |
+| `'max'`              | `gl.MAX_EXT`               |
 
-* `'min'` and `'max'` are only available if the `EXT_blend_minmax` extension is supported
-* `func` can be an object with the fields `{src, dst}` or `{srcRGB, srcAlpha, dstRGB, dstAlpha}`, with the former corresponding to `gl.blendFunc` and the latter to `gl.blendFuncSeparate`
-* The fields of `func` can take on the following values
+-   `'min'` and `'max'` are only available if the `EXT_blend_minmax` extension is supported
+-   `func` can be an object with the fields `{src, dst}` or `{srcRGB, srcAlpha, dstRGB, dstAlpha}`, with the former corresponding to `gl.blendFunc` and the latter to `gl.blendFuncSeparate`
+-   The fields of `func` can take on the following values
 
-| Func | Description |
-|------|-------------|
-| `0, 'zero'` | `gl.ZERO` |
-| `1, 'one'` | `gl.ONE` |
-| `'src color'` | `gl.SRC_COLOR` |
-| `'one minus src color'` | `gl.ONE_MINUS_SRC_COLOR` |
-| `'src alpha'` | `gl.SRC_ALPHA` |
-| `'one minus src alpha'` | `gl.ONE_MINUS_SRC_ALPHA` |
-| `'dst color'` | `gl.DST_COLOR` |
-| `'one minus dst color'` | `gl.ONE_MINUS_DST_COLOR` |
-| `'dst alpha'` | `gl.DST_ALPHA` |
-| `'one minus dst alpha'` | `gl.ONE_MINUS_DST_ALPHA` |
-| `'constant color'` | `gl.CONSTANT_COLOR` |
+| Func                         | Description                   |
+| ---------------------------- | ----------------------------- |
+| `0, 'zero'`                  | `gl.ZERO`                     |
+| `1, 'one'`                   | `gl.ONE`                      |
+| `'src color'`                | `gl.SRC_COLOR`                |
+| `'one minus src color'`      | `gl.ONE_MINUS_SRC_COLOR`      |
+| `'src alpha'`                | `gl.SRC_ALPHA`                |
+| `'one minus src alpha'`      | `gl.ONE_MINUS_SRC_ALPHA`      |
+| `'dst color'`                | `gl.DST_COLOR`                |
+| `'one minus dst color'`      | `gl.ONE_MINUS_DST_COLOR`      |
+| `'dst alpha'`                | `gl.DST_ALPHA`                |
+| `'one minus dst alpha'`      | `gl.ONE_MINUS_DST_ALPHA`      |
+| `'constant color'`           | `gl.CONSTANT_COLOR`           |
 | `'one minus constant color'` | `gl.ONE_MINUS_CONSTANT_COLOR` |
-| `'constant alpha'` | `gl.CONSTANT_ALPHA` |
+| `'constant alpha'`           | `gl.CONSTANT_ALPHA`           |
 | `'one minus constant alpha'` | `gl.ONE_MINUS_CONSTANT_ALPHA` |
-| `'src alpha saturate'` | `gl.SRC_ALPHA_SATURATE` |
+| `'src alpha saturate'`       | `gl.SRC_ALPHA_SATURATE`       |
 
 **Related WebGL APIs**
 
-* [`gl.blendEquationSeparate`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendEquationSeparate.xml)
-* [`gl.blendFuncSeparate`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendFuncSeparate.xml)
-* [`gl.blendColor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendColor.xml)
+-   [`gl.blendEquationSeparate`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendEquationSeparate.xml)
+-   [`gl.blendFuncSeparate`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendFuncSeparate.xml)
+-   [`gl.blendColor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendColor.xml)
 
----------------------------------------
+* * *
 
 #### Stencil
 
@@ -832,61 +985,61 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `enable` | Toggles `gl.enable(gl.STENCIL_TEST)` | `false` |
-| `mask` | Sets `gl.stencilMask` | `-1` |
-| `func` | Sets `gl.stencilFunc` | `{cmp:'always',ref:0,mask:-1}` |
+| Property  | Description                                | Default                                  |
+| --------- | ------------------------------------------ | ---------------------------------------- |
+| `enable`  | Toggles `gl.enable(gl.STENCIL_TEST)`       | `false`                                  |
+| `mask`    | Sets `gl.stencilMask`                      | `-1`                                     |
+| `func`    | Sets `gl.stencilFunc`                      | `{cmp:'always',ref:0,mask:-1}`           |
 | `opFront` | Sets `gl.stencilOpSeparate` for front face | `{fail:'keep',zfail:'keep',pass:'keep'}` |
-| `opBack` | Sets `gl.stencilOpSeparate` for back face | `{fail:'keep',zfail:'keep',pass:'keep'}` |
+| `opBack`  | Sets `gl.stencilOpSeparate` for back face  | `{fail:'keep',zfail:'keep',pass:'keep'}` |
 
 **Notes**
 
-* `func` is an object which configures the stencil test function. It has 3 properties,
+-   `func` is an object which configures the stencil test function. It has 3 properties,
 
-  * `cmp` which is the comparison function
-  * `ref` which is the reference value
-  * `mask` which is the comparison mask
+    -   `cmp` which is the comparison function
+    -   `ref` which is the reference value
+    -   `mask` which is the comparison mask
 
-* `func.cmp` is a comparison operator which takes one of the following values,
+-   `func.cmp` is a comparison operator which takes one of the following values,
 
-| Value | Description |
-|-------|-------------|
-| `'never'` | `gl.NEVER` |
-| `'always'` | `gl.ALWAYS` |
-| `'<', 'less'` | `gl.LESS` |
-| `'<=', 'lequal'` | `gl.LEQUAL` |
-| `'>', 'greater'` | `gl.GREATER` |
-| `'>=', 'gequal'` | `gl.GEQUAL` |
-| `'=', 'equal'` | `gl.EQUAL` |
+| Value              | Description   |
+| ------------------ | ------------- |
+| `'never'`          | `gl.NEVER`    |
+| `'always'`         | `gl.ALWAYS`   |
+| `'<', 'less'`      | `gl.LESS`     |
+| `'<=', 'lequal'`   | `gl.LEQUAL`   |
+| `'>', 'greater'`   | `gl.GREATER`  |
+| `'>=', 'gequal'`   | `gl.GEQUAL`   |
+| `'=', 'equal'`     | `gl.EQUAL`    |
 | `'!=', 'notequal'` | `gl.NOTEQUAL` |
 
-* `opFront` and `opBack` specify the stencil op.  Each is an object which takes the following parameters:
+-   `opFront` and `opBack` specify the stencil op.  Each is an object which takes the following parameters:
 
-  * `fail`, the stencil op which is applied when the stencil test fails
-  * `zfail`, the stencil op which is applied when the stencil test passes and the depth test fails
-  * `pass`, the stencil op which is applied when both stencil and depth tests pass
+    -   `fail`, the stencil op which is applied when the stencil test fails
+    -   `zfail`, the stencil op which is applied when the stencil test passes and the depth test fails
+    -   `pass`, the stencil op which is applied when both stencil and depth tests pass
 
-* Values for `opFront.fail`, `opFront.zfail`, etc. can come from the following table
+-   Values for `opFront.fail`, `opFront.zfail`, etc. can come from the following table
 
-| Stencil Op | Description |
-|------------|-------------|
-| `'zero'` | `gl.ZERO` |
-| `'keep'` | `gl.KEEP` |
-| `'replace'` | `gl.REPLACE` |
-| `'invert'` | `gl.INVERT` |
-| `'increment'` | `gl.INCR` |
-| `'decrement'` | `gl.DECR` |
+| Stencil Op         | Description    |
+| ------------------ | -------------- |
+| `'zero'`           | `gl.ZERO`      |
+| `'keep'`           | `gl.KEEP`      |
+| `'replace'`        | `gl.REPLACE`   |
+| `'invert'`         | `gl.INVERT`    |
+| `'increment'`      | `gl.INCR`      |
+| `'decrement'`      | `gl.DECR`      |
 | `'increment wrap'` | `gl.INCR_WRAP` |
 | `'decrement wrap'` | `gl.DECR_WRAP` |
 
 **Related WebGL APIs**
 
-* [`gl.stencilFunc`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glStencilFunc.xml)
-* [`gl.stencilMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glStencilMask.xml)
-* [`gl.stencilOpSeparate`](http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glStencilOpSeparate.xml)
+-   [`gl.stencilFunc`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glStencilFunc.xml)
+-   [`gl.stencilMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glStencilMask.xml)
+-   [`gl.stencilOpSeparate`](http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glStencilOpSeparate.xml)
 
----------------------------------------
+* * *
 
 #### Polygon offset
 
@@ -908,16 +1061,16 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `enable` | Toggles `gl.enable(gl.POLYGON_OFFSET_FILL)` | `false` |
-| `offset` | Sets `gl.polygonOffset` | `{factor:0, units:0}` |
+| Property | Description                                 | Default               |
+| -------- | ------------------------------------------- | --------------------- |
+| `enable` | Toggles `gl.enable(gl.POLYGON_OFFSET_FILL)` | `false`               |
+| `offset` | Sets `gl.polygonOffset`                     | `{factor:0, units:0}` |
 
 **Related WebGL APIs**
 
-* [`gl.polygonOffset`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPolygonOffset.xml)
+-   [`gl.polygonOffset`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPolygonOffset.xml)
 
----------------------------------------
+* * *
 
 #### Culling
 
@@ -936,25 +1089,25 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `enable` | Toggles `gl.enable(gl.CULL_FACE)` | `false` |
-| `face` | Sets `gl.cullFace` | `'back'` |
+| Property | Description                       | Default  |
+| -------- | --------------------------------- | -------- |
+| `enable` | Toggles `gl.enable(gl.CULL_FACE)` | `false`  |
+| `face`   | Sets `gl.cullFace`                | `'back'` |
 
 **Notes**
 
-* `face` must be one of the following values,
+-   `face` must be one of the following values,
 
-| Face | Description |
-|------|-------------|
-| `'front'` | `gl.FRONT` |
-| `'back'` | `gl.BACK` |
+| Face      | Description |
+| --------- | ----------- |
+| `'front'` | `gl.FRONT`  |
+| `'back'`  | `gl.BACK`   |
 
 **Relevant WebGL APIs**
 
-* [`gl.cullFace`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCullFace.xml)
+-   [`gl.cullFace`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCullFace.xml)
 
----------------------------------------
+* * *
 
 #### Front face
 
@@ -970,24 +1123,24 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
+| Property    | Description         | Default |
+| ----------- | ------------------- | ------- |
 | `frontFace` | Sets `gl.frontFace` | `'ccw'` |
 
 **Notes**
 
-* The value for front face must be one of the following,
+-   The value for front face must be one of the following,
 
 | Orientation | Description |
-|------|-------------|
-| `'cw'` | `gl.CW` |
-| `'ccw'` | `gl.CCW` |
+| ----------- | ----------- |
+| `'cw'`      | `gl.CW`     |
+| `'ccw'`     | `gl.CCW`    |
 
 **Relevant WebGL APIs**
 
-* [`gl.frontFace`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFrontFace.xml)
+-   [`gl.frontFace`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFrontFace.xml)
 
----------------------------------------
+* * *
 
 #### Dithering
 
@@ -1003,11 +1156,11 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
+| Property | Description         | Default |
+| -------- | ------------------- | ------- |
 | `dither` | Toggles `gl.DITHER` | `false` |
 
----------------------------------------
+* * *
 
 #### Line width
 
@@ -1023,15 +1176,15 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `lineWidth` | Sets `gl.lineWidth` | `1` |
+| Property    | Description         | Default |
+| ----------- | ------------------- | ------- |
+| `lineWidth` | Sets `gl.lineWidth` | `1`     |
 
 **Relevant WebGL APIs**
 
-* [`gl.lineWidth`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glLineWidth.xml)
+-   [`gl.lineWidth`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glLineWidth.xml)
 
----------------------------------------
+* * *
 
 #### Color mask
 
@@ -1047,15 +1200,15 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
+| Property    | Description         | Default                    |
+| ----------- | ------------------- | -------------------------- |
 | `colorMask` | Sets `gl.colorMask` | `[true, true, true, true]` |
 
 **Relevant WebGL APIs**
 
-* [`gl.colorMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
+-   [`gl.colorMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
 
----------------------------------------
+* * *
 
 #### Sample coverage
 
@@ -1078,17 +1231,17 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `enable` | Toggles `gl.enable(gl.SAMPLE_COVERAGE)` | `false` |
-| `alpha` | Toggles `gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE)` | `false` |
-| `coverage` | Sets `gl.sampleCoverage` | `{value:1,invert:false}` |
+| Property   | Description                                      | Default                  |
+| ---------- | ------------------------------------------------ | ------------------------ |
+| `enable`   | Toggles `gl.enable(gl.SAMPLE_COVERAGE)`          | `false`                  |
+| `alpha`    | Toggles `gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE)` | `false`                  |
+| `coverage` | Sets `gl.sampleCoverage`                         | `{value:1,invert:false}` |
 
 **Relevant WebGL APIs**
 
-* [`gl.sampleCoverage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
+-   [`gl.sampleCoverage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
 
----------------------------------------
+* * *
 
 #### Scissor
 
@@ -1112,25 +1265,25 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
+| Property | Description                     | Default |
+| -------- | ------------------------------- | ------- |
 | `enable` | Toggles `gl.enable(gl.SCISSOR)` | `false` |
-| `box` | Sets `gl.scissor` | `{}` |
+| `box`    | Sets `gl.scissor`               | `{}`    |
 
 **Notes**
 
-* `box` is the shape of the scissor region, it takes the following parameters
+-   `box` is the shape of the scissor region, it takes the following parameters
 
-  * `x` is the left coordinate of the box, default `0`
-  * `y` is the top coordiante of the box, default `0`
-  * `width` is the width of the box, default fbo width - `x`
-  * `height` is the height of the box, default fbo height - `y`
+    -   `x` is the left coordinate of the box, default `0`
+    -   `y` is the top coordiante of the box, default `0`
+    -   `width` is the width of the box, default fbo width - `x`
+    -   `height` is the height of the box, default fbo height - `y`
 
 **Relevant WebGL APIs**
 
-* [`gl.scissor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glScissor.xml)
+-   [`gl.scissor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glScissor.xml)
 
----------------------------------------
+* * *
 
 #### Viewport
 
@@ -1151,26 +1304,26 @@ var command = regl({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `viewport` | The shape of viewport | `{}` |
+| Property   | Description           | Default |
+| ---------- | --------------------- | ------- |
+| `viewport` | The shape of viewport | `{}`    |
 
 **Notes**
 
-* Like `scissor.box`, `viewport` is a bounding box with properties `x,y,w,h`
-* Updating `viewport` will modify the context variables `viewportWidth` and `viewportHeight`
+-   Like `scissor.box`, `viewport` is a bounding box with properties `x,y,w,h`
+-   Updating `viewport` will modify the context variables `viewportWidth` and `viewportHeight`
 
 **Relevant WebGL APIs**
 
-* [`gl.viewport`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glViewport.xml)
+-   [`gl.viewport`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glViewport.xml)
 
----------------------------------------
+* * *
 
 ## Resources
 
 Besides commands, the other major component of regl are resources.  Resources are GPU resident objects which are managed explicitly by the programmer.  Each resource follows a the same life cycle of create/read/update/delete.
 
----------------------------------------
+* * *
 
 ### Buffers
 
@@ -1199,22 +1352,22 @@ var positionBuffer = regl.buffer([
 ])
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `data` | The data for the vertex buffer (see below) | `null` |
-| `length` | If `data` is `null` or not present reserves space for the buffer | `0` |
-| `usage` | Sets array buffer usage hint | `'static'` |
+| Property | Description                                                      | Default    |
+| -------- | ---------------------------------------------------------------- | ---------- |
+| `data`   | The data for the vertex buffer (see below)                       | `null`     |
+| `length` | If `data` is `null` or not present reserves space for the buffer | `0`        |
+| `usage`  | Sets array buffer usage hint                                     | `'static'` |
 
-| Usage Hint | Description |
-|------------|-------------|
-| `'static'` | `gl.DRAW_STATIC` |
+| Usage Hint  | Description       |
+| ----------- | ----------------- |
+| `'static'`  | `gl.DRAW_STATIC`  |
 | `'dynamic'` | `gl.DYNAMIC_DRAW` |
-| `'stream'` | `gl.STREAM_DRAW` |
+| `'stream'`  | `gl.STREAM_DRAW`  |
 
 **Relevant WebGL APIs**
 
-* [`gl.createBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateBuffer.xml)
-* [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
+-   [`gl.createBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateBuffer.xml)
+-   [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 
 #### Buffer update
 
@@ -1238,7 +1391,7 @@ The arguments to the update pathway are the same as the constructor and the retu
 
 **Relevant WebGL APIs**
 
-* [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
+-   [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 
 ##### Buffer subdata
 
@@ -1273,7 +1426,7 @@ myBuffer.subdata([[7, 8], [9, 10]], 8)
 
 **Relevant WebGL APIs**
 
-* [`gl.bufferSubData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferSubData.xml)
+-   [`gl.bufferSubData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferSubData.xml)
 
 #### Buffer destructor
 
@@ -1287,17 +1440,17 @@ var myBuffer = regl.buffer(10)
 myBuffer.destroy()
 ```
 
-* [`gl.deleteBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteBuffer.xml)
+-   [`gl.deleteBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteBuffer.xml)
 
 #### Profiling info
 
 The following stats are tracked for each buffer in the `.stats` property:
 
-| Statistic | Meaning |
-|-----------|---------|
-| `size` | The size of the buffer in bytes |
+| Statistic | Meaning                         |
+| --------- | ------------------------------- |
+| `size`    | The size of the buffer in bytes |
 
----------------------------------------
+* * *
 
 ### Elements
 
@@ -1318,43 +1471,43 @@ var starElements = regl.elements({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `data` | The data of the element buffer | `null` |
-| `usage` | Usage hint (see `gl.bufferData`) | `'static'` |
-| `length` | Length of the element buffer in bytes | `0` * |
-| `primitive` | Default primitive type for element buffer | `'triangles'` * |
-| `count` | Vertex count for element buffer | `0` * |
+| Property    | Description                               | Default          |
+| ----------- | ----------------------------------------- | ---------------- |
+| `data`      | The data of the element buffer            | `null`           |
+| `usage`     | Usage hint (see `gl.bufferData`)          | `'static'`       |
+| `length`    | Length of the element buffer in bytes     | `0` \*           |
+| `primitive` | Default primitive type for element buffer | `'triangles'` \* |
+| `count`     | Vertex count for element buffer           | `0` \*           |
 
-* `usage` must take on one of the following values
+-   `usage` must take on one of the following values
 
-| Usage Hint | Description |
-|------------|-------------|
-| `'static'` | `gl.DRAW_STATIC` |
+| Usage Hint  | Description       |
+| ----------- | ----------------- |
+| `'static'`  | `gl.DRAW_STATIC`  |
 | `'dynamic'` | `gl.DYNAMIC_DRAW` |
-| `'stream'` | `gl.STREAM_DRAW` |
+| `'stream'`  | `gl.STREAM_DRAW`  |
 
-* `primitive` can be one of the following primitive types
+-   `primitive` can be one of the following primitive types
 
-| Primitive type | Description |
-|-------|-------------|
-| `'points'` | `gl.POINTS` |
-| `'lines'` | `gl.LINES` |
-| `'line strip'` | `gl.LINE_STRIP` |
-| `'line loop` | `gl.LINE_LOOP` |
-| `'triangles` | `gl.TRIANGLES` |
+| Primitive type     | Description         |
+| ------------------ | ------------------- |
+| `'points'`         | `gl.POINTS`         |
+| `'lines'`          | `gl.LINES`          |
+| `'line strip'`     | `gl.LINE_STRIP`     |
+| `'line loop`       | `gl.LINE_LOOP`      |
+| `'triangles`       | `gl.TRIANGLES`      |
 | `'triangle strip'` | `gl.TRIANGLE_STRIP` |
-| `'triangle fan'` | `gl.TRIANGLE_FAN` |
+| `'triangle fan'`   | `gl.TRIANGLE_FAN`   |
 
 **Notes**
 
-* `primitive`, `count` and `length` are inferred from from the vertex data
+-   `primitive`, `count` and `length` are inferred from from the vertex data
 
 **Relevant WebGL APIs**
 
-* [`gl.createBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateBuffer.xml)
-* [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
-* [`gl.drawElements`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawElements.xml)
+-   [`gl.createBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateBuffer.xml)
+-   [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
+-   [`gl.drawElements`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawElements.xml)
 
 #### Element update
 
@@ -1375,7 +1528,7 @@ myElements({
 
 **Relevant WebGL APIs**
 
-* [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
+-   [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 
 ##### Element subdata
 
@@ -1399,7 +1552,7 @@ myElements.subdata(
 
 **Relevant WebGL APIs**
 
-* [`gl.bufferSubData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferSubData.xml)
+-   [`gl.bufferSubData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferSubData.xml)
 
 #### Element destructor
 
@@ -1414,9 +1567,9 @@ myElements.destroy()
 
 **Relevant WebGL APIs**
 
-* [`gl.deleteBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteBuffer.xml)
+-   [`gl.deleteBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteBuffer.xml)
 
----------------------------------------
+* * *
 
 ### Textures
 
@@ -1481,43 +1634,43 @@ var copyPixels = regl.texture({
 
 A data source from an image can be one of the following types:
 
-| Data type | Description |
-|-----------|-------------|
-| Rectangular array of arrays | Interpreted as 2D array of arrays |
-| Typed array | A binary array of pixel values |
-| Array | Interpreted as array of pixel values with type based on the input type |
-| `ndarray` | Any object with a `shape, stride, offset, data` (see [SciJS ndarray](https://github.com/scijs/ndarray))|
-| Image | An HTML image element |
-| Video | An HTML video element |
-| Canvas | A canvas element |
-| Context 2D | A canvas 2D context |
+| Data type                   | Description                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Rectangular array of arrays | Interpreted as 2D array of arrays                                                                       |
+| Typed array                 | A binary array of pixel values                                                                          |
+| Array                       | Interpreted as array of pixel values with type based on the input type                                  |
+| `ndarray`                   | Any object with a `shape, stride, offset, data` (see [SciJS ndarray](https://github.com/scijs/ndarray)) |
+| Image                       | An HTML image element                                                                                   |
+| Video                       | An HTML video element                                                                                   |
+| Canvas                      | A canvas element                                                                                        |
+| Context 2D                  | A canvas 2D context                                                                                     |
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `width` | Width of texture | `0` |
-| `height` | Height of texture | `0` |
-| `mag` | Sets magnification filter (see table) | `'nearest'` |
-| `min` | Sets minification filter (see table) | `'nearest'` |
-| `wrapS` | Sets wrap mode on S axis (see table) | `'repeat'` |
-| `wrapT` | Sets wrap mode on T axis (see table) | `'repeat'` |
-| `aniso` | Sets number of anisotropic samples, requires [EXT_texture_filter_anisotropic](https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/) | `0` |
-| `format` | Texture format (see table) | `'rgba'` |
-| `type` | Texture type (see table) | `'uint8'` |
-| `data` | Input data (see below) | |
-| `mipmap` | See below for a description | `false` |
-| `flipY` | Flips textures vertically when uploading | `false` |
-| `alignment` | Sets unpack alignment per pixel | `1` |
-| `premultiplyAlpha` | Premultiply alpha when unpacking | `false` |
-| `colorSpace` | Sets colorspace conversion | `'none'` |
-| `data` | Image data for the texture | `null` |
+| Property           | Description                                                                                                                                                      | Default     |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `width`            | Width of texture                                                                                                                                                 | `0`         |
+| `height`           | Height of texture                                                                                                                                                | `0`         |
+| `mag`              | Sets magnification filter (see table)                                                                                                                            | `'nearest'` |
+| `min`              | Sets minification filter (see table)                                                                                                                             | `'nearest'` |
+| `wrapS`            | Sets wrap mode on S axis (see table)                                                                                                                             | `'repeat'`  |
+| `wrapT`            | Sets wrap mode on T axis (see table)                                                                                                                             | `'repeat'`  |
+| `aniso`            | Sets number of anisotropic samples, requires [EXT_texture_filter_anisotropic](https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/) | `0`         |
+| `format`           | Texture format (see table)                                                                                                                                       | `'rgba'`    |
+| `type`             | Texture type (see table)                                                                                                                                         | `'uint8'`   |
+| `data`             | Input data (see below)                                                                                                                                           |             |
+| `mipmap`           | See below for a description                                                                                                                                      | `false`     |
+| `flipY`            | Flips textures vertically when uploading                                                                                                                         | `false`     |
+| `alignment`        | Sets unpack alignment per pixel                                                                                                                                  | `1`         |
+| `premultiplyAlpha` | Premultiply alpha when unpacking                                                                                                                                 | `false`     |
+| `colorSpace`       | Sets colorspace conversion                                                                                                                                       | `'none'`    |
+| `data`             | Image data for the texture                                                                                                                                       | `null`      |
 
-* `mipmap`. If `boolean`, then it sets whether or not we should regenerate the mipmaps. If a `string`, it allows you to specify a hint to the mipmap generator. It can be one of the hints below
+-   `mipmap`. If `boolean`, then it sets whether or not we should regenerate the mipmaps. If a `string`, it allows you to specify a hint to the mipmap generator. It can be one of the hints below
 
-| Mipmap Hint | Description |
-|-------|-------------|
-| `'don't care'`, `'dont care'`  | `gl.DONT_CARE` |
-| `'nice'` | `gl.NICEST` |
-| `'fast'` | `gl.FASTEST` |
+| Mipmap Hint                   | Description    |
+| ----------------------------- | -------------- |
+| `'don't care'`, `'dont care'` | `gl.DONT_CARE` |
+| `'nice'`                      | `gl.NICEST`    |
+| `'fast'`                      | `gl.FASTEST`   |
 
 and if a hint is specified, then also the mipmaps will be regenerated. Finally, `mipmap` can also be an array of arrays. In this case, every subarray will be one of the mipmaps, and you can thus use this option to manually specify the mipmaps of the image. Like this:
 
@@ -1536,96 +1689,96 @@ regl.texture({
 })
 ```
 
-* `shape` can be used as an array shortcut for `[width, height, channels]` of image
-* `radius` can be specified for square images and sets both `width` and `height`
-* `data` can take one of the following values,
-* If an image element is specified and not yet loaded, then regl will upload a temporary image and hook a callback on the image
-* `mag` sets `gl.MAG_FILTER` for the texture and can have one of the following values
+-   `shape` can be used as an array shortcut for `[width, height, channels]` of image
+-   `radius` can be specified for square images and sets both `width` and `height`
+-   `data` can take one of the following values,
+-   If an image element is specified and not yet loaded, then regl will upload a temporary image and hook a callback on the image
+-   `mag` sets `gl.MAG_FILTER` for the texture and can have one of the following values
 
-| Mag filter | Description |
-|------------|-------------|
+| Mag filter  | Description  |
+| ----------- | ------------ |
 | `'nearest'` | `gl.NEAREST` |
-| `'linear'` | `gl.LINEAR` |
+| `'linear'`  | `gl.LINEAR`  |
 
-* `min` sets `gl.MIN_FILTER` for the texture, and can take on one of the following values,
+-   `min` sets `gl.MIN_FILTER` for the texture, and can take on one of the following values,
 
-| Min filter | Description |
-|------------|-------------|
-| `'nearest'` | `gl.NEAREST` |
-| `'linear'` | `gl.LINEAR` |
-| `'mipmap', 'linear mipmap linear'` | `gl.LINEAR_MIPMAP_LINEAR` |
-| `'nearest mipmap linear'` | `gl.NEAREST_MIPMAP_LINEAR` |
-| `'linear mipmap nearest'` | `gl.LINEAR_MIPMAP_NEAREST` |
-| `'nearest mipmap nearest'` | `gl.NEAREST_MIPMAP_NEAREST` |
+| Min filter                         | Description                 |
+| ---------------------------------- | --------------------------- |
+| `'nearest'`                        | `gl.NEAREST`                |
+| `'linear'`                         | `gl.LINEAR`                 |
+| `'mipmap', 'linear mipmap linear'` | `gl.LINEAR_MIPMAP_LINEAR`   |
+| `'nearest mipmap linear'`          | `gl.NEAREST_MIPMAP_LINEAR`  |
+| `'linear mipmap nearest'`          | `gl.LINEAR_MIPMAP_NEAREST`  |
+| `'nearest mipmap nearest'`         | `gl.NEAREST_MIPMAP_NEAREST` |
 
-* `wrap` can be used as an array shortcut for `[wrapS, wrapT]`
-* `wrapS` and `wrapT` can have any of the following values,
+-   `wrap` can be used as an array shortcut for `[wrapS, wrapT]`
+-   `wrapS` and `wrapT` can have any of the following values,
 
-| Wrap mode | Description |
-|-----------|-------------|
-| `'repeat'` | `gl.REPEAT` |
-| `'clamp'` | `gl.CLAMP_TO_EDGE` |
+| Wrap mode  | Description          |
+| ---------- | -------------------- |
+| `'repeat'` | `gl.REPEAT`          |
+| `'clamp'`  | `gl.CLAMP_TO_EDGE`   |
 | `'mirror'` | `gl.MIRRORED_REPEAT` |
 
-* `format` determines the format of the texture and possibly the type.  Possible values for `format` include,
+-   `format` determines the format of the texture and possibly the type.  Possible values for `format` include,
 
-| Format | Description | Channels | Types | Compressed? | Extension? |
-|--------|-------------|----------|-------|------|------------|
-| `'alpha'` | `gl.ALPHA` | 1 | `'uint8','half float','float'` | ✖ | |
-| `'luminance'` | `gl.LUMINANCE` | 1 | `'uint8','half float','float'` | ✖ | |
-| `'luminance alpha'` | `gl.LUMINANCE_ALPHA` | 2 | `'uint8','half float','float'` | ✖ | |
-| `'rgb'` | `gl.RGB` | 3 | `'uint8','half float','float'` | ✖ | |
-| `'rgba'` | `gl.RGBA` | 4  | `'uint8','half float','float'`| ✖ | |
-| `'rgba4'` | `gl.RGBA4` | 4 | `'rgba4'` | ✖ | |
-| `'rgb5 a1'` | `gl.RGB5_A1` | 4 | `'rgb5 a1'` | ✖ | |
-| `'rgb565'` | `gl.RGB565` | 3 | `'rgb565'` | ✖ | |
-| `'srgb'` | `ext.SRGB` | 3 | `'uint8','half float','float'` | ✖ | [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) |
-| `'srgba'` | `ext.RGBA` | 4  | `'uint8','half float','float'`| ✖ | [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) |
-| `'depth'` | `gl.DEPTH_COMPONENT` | 1 | `'uint16','uint32'`  | ✖ | [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) |
-| `'depth stencil'` | `gl.DEPTH_STENCIL` | 2 | `'depth stencil'` | ✖ | [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) |
-| `'rgb s3tc dxt1'` | `ext.COMPRESSED_RGB_S3TC_DXT1_EXT` | 3 | `'uint8'` | ✓ | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/) |
-| `'rgba s3tc dxt1'` | `ext.COMPRESSED_RGBA_S3TC_DXT1_EXT` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/) |
-| `'rgba s3tc dxt3'` | `ext.COMPRESSED_RGBA_S3TC_DXT3_EXT` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/) |
-| `'rgba s3tc dxt5'` | `ext.COMPRESSED_RGBA_S3TC_DXT5_EXT` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/) |
-| `'rgb atc'` | `ext.COMPRESSED_RGB_ATC_WEBGL` | 3 | `'uint8'` | ✓ | [WEBGL_compressed_texture_atc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/) |
-| `'rgba atc explicit alpha'` | `ext.COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_atc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/) |
-| `'rgba atc interpolated alpha'` | `ext.COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_atc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/) |
-| `'rgb pvrtc 4bppv1'` | `ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG` | 3 | `'uint8'` | ✓ | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
-| `'rgb pvrtc 2bppv1'` | `ext.COMPRESSED_RGB_PVRTC_2BPPV1_IMG` | 3 | `'uint8'` | ✓ | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
-| `'rgba pvrtc 4bppv1'` | `ext.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
-| `'rgba pvrtc 2bppv1'` | `ext.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG` | 4 | `'uint8'` | ✓ | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
-| `'rgb etc1'` | `ext.COMPRESSED_RGB_ETC1_WEBGL` | 3 | `'uint8'` | ✓ | [WEBGL_compressed_texture_etc1](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/) |
+| Format                          | Description                                        | Channels | Types                          | Compressed? | Extension?                                                                                                          |
+| ------------------------------- | -------------------------------------------------- | -------- | ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| `'alpha'`                       | `gl.ALPHA`                                         | 1        | `'uint8','half float','float'` | ✖           |                                                                                                                     |
+| `'luminance'`                   | `gl.LUMINANCE`                                     | 1        | `'uint8','half float','float'` | ✖           |                                                                                                                     |
+| `'luminance alpha'`             | `gl.LUMINANCE_ALPHA`                               | 2        | `'uint8','half float','float'` | ✖           |                                                                                                                     |
+| `'rgb'`                         | `gl.RGB`                                           | 3        | `'uint8','half float','float'` | ✖           |                                                                                                                     |
+| `'rgba'`                        | `gl.RGBA`                                          | 4        | `'uint8','half float','float'` | ✖           |                                                                                                                     |
+| `'rgba4'`                       | `gl.RGBA4`                                         | 4        | `'rgba4'`                      | ✖           |                                                                                                                     |
+| `'rgb5 a1'`                     | `gl.RGB5_A1`                                       | 4        | `'rgb5 a1'`                    | ✖           |                                                                                                                     |
+| `'rgb565'`                      | `gl.RGB565`                                        | 3        | `'rgb565'`                     | ✖           |                                                                                                                     |
+| `'srgb'`                        | `ext.SRGB`                                         | 3        | `'uint8','half float','float'` | ✖           | [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/)                                             |
+| `'srgba'`                       | `ext.RGBA`                                         | 4        | `'uint8','half float','float'` | ✖           | [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/)                                             |
+| `'depth'`                       | `gl.DEPTH_COMPONENT`                               | 1        | `'uint16','uint32'`            | ✖           | [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/)                       |
+| `'depth stencil'`               | `gl.DEPTH_STENCIL`                                 | 2        | `'depth stencil'`              | ✖           | [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/)                       |
+| `'rgb s3tc dxt1'`               | `ext.COMPRESSED_RGB_S3TC_DXT1_EXT`                 | 3        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/)   |
+| `'rgba s3tc dxt1'`              | `ext.COMPRESSED_RGBA_S3TC_DXT1_EXT`                | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/)   |
+| `'rgba s3tc dxt3'`              | `ext.COMPRESSED_RGBA_S3TC_DXT3_EXT`                | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/)   |
+| `'rgba s3tc dxt5'`              | `ext.COMPRESSED_RGBA_S3TC_DXT5_EXT`                | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_s3tc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/)   |
+| `'rgb atc'`                     | `ext.COMPRESSED_RGB_ATC_WEBGL`                     | 3        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_atc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/)     |
+| `'rgba atc explicit alpha'`     | `ext.COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL`     | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_atc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/)     |
+| `'rgba atc interpolated alpha'` | `ext.COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL` | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_atc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/)     |
+| `'rgb pvrtc 4bppv1'`            | `ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG`              | 3        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
+| `'rgb pvrtc 2bppv1'`            | `ext.COMPRESSED_RGB_PVRTC_2BPPV1_IMG`              | 3        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
+| `'rgba pvrtc 4bppv1'`           | `ext.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG`             | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
+| `'rgba pvrtc 2bppv1'`           | `ext.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG`             | 4        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_pvrtc](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/) |
+| `'rgb etc1'`                    | `ext.COMPRESSED_RGB_ETC1_WEBGL`                    | 3        | `'uint8'`                      | ✓           | [WEBGL_compressed_texture_etc1](https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/)   |
 
-* In many cases `type` can be inferred from the format and other information in the texture.  However, in some situations it may still be necessary to set it manually.  In such an event, the following values are possible,
+-   In many cases `type` can be inferred from the format and other information in the texture.  However, in some situations it may still be necessary to set it manually.  In such an event, the following values are possible,
 
-| Type | Description |
-|------|-------------|
-| `'uint8'` | `gl.UNSIGNED_BYTE` |
-| `'uint16'` | `gl.UNSIGNED_SHORT` |
-| `'uint32'` | `gl.UNSIGNED_INT` |
-| `'float', 'float32'` | `gl.FLOAT` |
+| Type                      | Description          |
+| ------------------------- | -------------------- |
+| `'uint8'`                 | `gl.UNSIGNED_BYTE`   |
+| `'uint16'`                | `gl.UNSIGNED_SHORT`  |
+| `'uint32'`                | `gl.UNSIGNED_INT`    |
+| `'float', 'float32'`      | `gl.FLOAT`           |
 | `'half float', 'float16'` | `ext.HALF_FLOAT_OES` |
 
-* `colorSpace` sets the WebGL color space flag for pixel unpacking
+-   `colorSpace` sets the WebGL color space flag for pixel unpacking
 
-| Color space | Description |
-|------------|-------------|
-| `'none'` | `gl.NONE` |
+| Color space | Description                |
+| ----------- | -------------------------- |
+| `'none'`    | `gl.NONE`                  |
 | `'browser'` | `gl.BROWSER_DEFAULT_WEBGL` |
 
-* `unpackAlignment` sets the pixel unpack alignment and must be one of `[1, 2, 4, 8]`
+-   `unpackAlignment` sets the pixel unpack alignment and must be one of `[1, 2, 4, 8]`
 
 **Relevant WebGL APIs**
 
-* [`gl.createTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateTexture.xml)
-* [`gl.texParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml)
-*  [`gl.pixelStorei`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
-* [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
-* [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
-* [`gl.compressedTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexImage2D.xml)
-* [`gl.copyTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexImage2D.xml)
-* [`gl.generateMipmap`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenerateMipmap.xml)
-* [`gl.hint`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glHint.xml)
+-   [`gl.createTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateTexture.xml)
+-   [`gl.texParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml)
+-   [`gl.pixelStorei`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
+-   [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
+-   [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
+-   [`gl.compressedTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexImage2D.xml)
+-   [`gl.copyTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexImage2D.xml)
+-   [`gl.generateMipmap`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenerateMipmap.xml)
+-   [`gl.hint`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glHint.xml)
 
 #### Texture update
 
@@ -1646,14 +1799,14 @@ Doing this lets you defer texture construction or reuse texture objects.
 
 **Relevant WebGL APIs**
 
-* [`gl.createTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateTexture.xml)
-* [`gl.texParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml)
-*  [`gl.pixelStorei`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
-* [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
-* [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
-* [`gl.compressedTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexImage2D.xml)
-* [`gl.copyTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexImage2D.xml)
-* [`gl.generateMipmap`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenerateMipmap.xml)
+-   [`gl.createTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateTexture.xml)
+-   [`gl.texParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml)
+-   [`gl.pixelStorei`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
+-   [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
+-   [`gl.texImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml)
+-   [`gl.compressedTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexImage2D.xml)
+-   [`gl.copyTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexImage2D.xml)
+-   [`gl.generateMipmap`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenerateMipmap.xml)
 
 ##### Texture subimage
 
@@ -1677,15 +1830,15 @@ texture.subimage(data[, x, y, level])
 
 Where,
 
-* `data` is an image data object, similar to the arguments for the texture constructor
-* `x, y` is the offset of the subimage within the texture (default `0,0`)
-* `level` is the miplevel to run the subimage within (default `0`)
+-   `data` is an image data object, similar to the arguments for the texture constructor
+-   `x, y` is the offset of the subimage within the texture (default `0,0`)
+-   `level` is the miplevel to run the subimage within (default `0`)
 
 **Relevant WebGL APIs**
 
-* [`gl.texSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexSubImage2D.xml)
-* [`gl.copyTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexSubImage2D.xml)
-* [`gl.compressedTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexSubImage2D.xml)
+-   [`gl.texSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexSubImage2D.xml)
+-   [`gl.copyTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexSubImage2D.xml)
+-   [`gl.compressedTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexSubImage2D.xml)
 
 ##### Texture resize
 
@@ -1709,17 +1862,17 @@ myTexture.destroy()
 
 **Relevant WebGL APIs**
 
-*  [`gl.deleteTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteTexture.xml)
+-   [`gl.deleteTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteTexture.xml)
 
 #### Texture profiling
 
 The following stats are tracked for each texture in the `.stats` property:
 
-| Statistic | Meaning |
-|-----------|---------|
-| `size` | The size of the texture in bytes |
+| Statistic | Meaning                          |
+| --------- | -------------------------------- |
+| `size`    | The size of the texture in bytes |
 
----------------------------------------
+* * *
 
 ### Cube maps
 
@@ -1791,9 +1944,9 @@ cube.subimage(face, data[, x, y, miplevel])
 
 **Relevant WebGL APIs**
 
-* [`gl.texSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexSubImage2D.xml)
-* [`gl.copyTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexSubImage2D.xml)
-* [`gl.compressedTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexSubImage2D.xml)
+-   [`gl.texSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexSubImage2D.xml)
+-   [`gl.copyTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexSubImage2D.xml)
+-   [`gl.compressedTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexSubImage2D.xml)
 
 #### Cube map resize
 
@@ -1809,9 +1962,9 @@ cubemap.resize(16)
 
 The following stats are tracked for each cube map in the `.stats` property:
 
-| Statistic | Meaning |
-|-----------|---------|
-| `size` | The size of the cube map in bytes |
+| Statistic | Meaning                           |
+| --------- | --------------------------------- |
+| `size`    | The size of the cube map in bytes |
 
 #### Cube map destructor
 
@@ -1821,9 +1974,9 @@ cubeMap.destroy()
 
 **Relevant WebGL APIs**
 
-*  [`gl.deleteTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteTexture.xml)
+-   [`gl.deleteTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteTexture.xml)
 
----------------------------------------
+* * *
 
 ### Renderbuffers
 
@@ -1841,33 +1994,33 @@ var rb = regl.renderbuffer({
 var rgba_16x24 = regl.renderbuffer(16, 24)
 ```
 
-| Property | Interpretation | Default |
-|----------|----------------|---------|
+| Property   | Interpretation                                            | Default   |
+| ---------- | --------------------------------------------------------- | --------- |
 | `'format'` | Sets the internal format of the render buffer (see below) | `'rgba4'` |
-| `'width'` | Sets the width of the render buffer in pixels | `1` |
-| `'height'` | Sets the height of the render buffer in pixels | `1` |
-| `'shape'` | Alias for width and height | `[1,1]` |
-| `'radius'` | Simultaneously sets width and height | `1` |
+| `'width'`  | Sets the width of the render buffer in pixels             | `1`       |
+| `'height'` | Sets the height of the render buffer in pixels            | `1`       |
+| `'shape'`  | Alias for width and height                                | `[1,1]`   |
+| `'radius'` | Simultaneously sets width and height                      | `1`       |
 
-| Format | Description |
-|--------|-------------|
-| `'rgba4'` | `gl.RGBA4` |
-| `'rgb565'` | `gl.RGB565` |
-| `'rgb5 a1'` | `gl.RGB5_A1` |
-| `'depth'` | `gl.DEPTH_COMPONENT16` |
-| `'stencil'` | `gl.STENCIL_INDEX8` |
-| `'depth stencil'` | `gl.DEPTH_STENCIL` |
-| `'srgba'` | `ext.SRGB8_ALPHA8_EXT`, only if [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) supported |
-| `'rgba16f'` | 16 bit floating point RGBA buffer, only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/) |
-| `'rgb16f'` | 16 bit floating point RGB buffer, only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/) |
-| `'rgba32f'` | 32 bit floating point RGBA buffer, only if [WEBGL_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/) supported |
+| Format            | Description                                                                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `'rgba4'`         | `gl.RGBA4`                                                                                                                                                   |
+| `'rgb565'`        | `gl.RGB565`                                                                                                                                                  |
+| `'rgb5 a1'`       | `gl.RGB5_A1`                                                                                                                                                 |
+| `'depth'`         | `gl.DEPTH_COMPONENT16`                                                                                                                                       |
+| `'stencil'`       | `gl.STENCIL_INDEX8`                                                                                                                                          |
+| `'depth stencil'` | `gl.DEPTH_STENCIL`                                                                                                                                           |
+| `'srgba'`         | `ext.SRGB8_ALPHA8_EXT`, only if [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) supported                                            |
+| `'rgba16f'`       | 16 bit floating point RGBA buffer, only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)     |
+| `'rgb16f'`        | 16 bit floating point RGB buffer, only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)      |
+| `'rgba32f'`       | 32 bit floating point RGBA buffer, only if [WEBGL_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/) supported |
 
 **Relevant WebGL APIs**
 
-* [`gl.createRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateRenderbuffer.xml)
-* [`gl.deleteRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteRenderbuffer.xml)
-* [`gl.renderbufferStorage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glRenderbufferStorage.xml)
-* [`gl.bindRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindRenderbuffer.xml)
+-   [`gl.createRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateRenderbuffer.xml)
+-   [`gl.deleteRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteRenderbuffer.xml)
+-   [`gl.renderbufferStorage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glRenderbufferStorage.xml)
+-   [`gl.bindRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindRenderbuffer.xml)
 
 #### Renderbuffer update
 
@@ -1903,17 +2056,17 @@ rb.destroy()
 
 **Relevant WebGL APIs**
 
-* [`gl.deleteRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteRenderbuffer.xml)
+-   [`gl.deleteRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteRenderbuffer.xml)
 
 #### Renderbuffer profiling
 
 The following stats are tracked for each renderbuffer in the `.stats` property:
 
-| Statistic | Meaning |
-|-----------|---------|
-| `size` | The size of the renderbuffer in bytes |
+| Statistic | Meaning                               |
+| --------- | ------------------------------------- |
+| `size`    | The size of the renderbuffer in bytes |
 
----------------------------------------
+* * *
 
 ### Framebuffers
 
@@ -1937,48 +2090,48 @@ var texFBO = regl.framebuffer({
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `width` | Sets the width of the framebuffer | `gl.drawingBufferWidth` |
-| `height` | Sets the height of the framebuffer | `gl.drawingBufferHeight` |
-| `color` | An optional array of either textures renderbuffers for the color attachment. | |
-| `depth` | If boolean, then toggles the depth attachment.  Otherwise if a renderbuffer/texture sets the depth attachment. | `true` |
-| `stencil` | If boolean, then toggles the stencil attachment.  Otherwise if a renderbuffer sets the stencil attachment. | `true` |
-| `depthStencil` | If boolean, then toggles both the depth and stencil attachment.  Otherwise if a renderbuffer/texture sets the combined depth/stencil attachment. | `true` |
-| `colorFormat` | Sets the format of the color buffer.  Ignored if color | `'rgba'` |
-| `colorType` | Sets the type of the color buffer if it is a texture | `'uint8'` |
-| `colorCount` | Sets the number of color buffers. Values > 1 require [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/) | `1` |
-| `depthTexture` | Toggles whether depth/stencil attachments should be in texture. Requires [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) | `false` |
+| Property       | Description                                                                                                                                                            | Default                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `width`        | Sets the width of the framebuffer                                                                                                                                      | `gl.drawingBufferWidth`  |
+| `height`       | Sets the height of the framebuffer                                                                                                                                     | `gl.drawingBufferHeight` |
+| `color`        | An optional array of either textures renderbuffers for the color attachment.                                                                                           |                          |
+| `depth`        | If boolean, then toggles the depth attachment.  Otherwise if a renderbuffer/texture sets the depth attachment.                                                         | `true`                   |
+| `stencil`      | If boolean, then toggles the stencil attachment.  Otherwise if a renderbuffer sets the stencil attachment.                                                             | `true`                   |
+| `depthStencil` | If boolean, then toggles both the depth and stencil attachment.  Otherwise if a renderbuffer/texture sets the combined depth/stencil attachment.                       | `true`                   |
+| `colorFormat`  | Sets the format of the color buffer.  Ignored if color                                                                                                                 | `'rgba'`                 |
+| `colorType`    | Sets the type of the color buffer if it is a texture                                                                                                                   | `'uint8'`                |
+| `colorCount`   | Sets the number of color buffers. Values > 1 require [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/)                       | `1`                      |
+| `depthTexture` | Toggles whether depth/stencil attachments should be in texture. Requires [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) | `false`                  |
 
-| Color format | Description | Attachment | Notes |
-|--------------|-------------|------------|-----|
-| `'rgba'` | `gl.RGBA` | Texture |              |
-| `'rgba4'` | `gl.RGBA4` | Renderbuffer |    |
-| `'rgb565'` | `gl.RGB565` | Renderbuffer |    |
-| `'rgb5 a1'` | `gl.RGB5_A1` | Renderbuffer |    |
-| `'rgb16f'` | `gl.RGB16F` | Renderbuffer |   only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)  |
-| `'rgba16f'` | `gl.RGBA16F` | Renderbuffer | only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)   |
-| `'rgba32f'` | `gl.RGBA32F` | Renderbuffer |  only if [WEBGL_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/) supported  |
-| `'srgba'` | `gl.SRGB8_ALPHA8` | Renderbuffer | only if [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) supported  |
+| Color format | Description       | Attachment   | Notes                                                                                                                     |
+| ------------ | ----------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `'rgba'`     | `gl.RGBA`         | Texture      |                                                                                                                           |
+| `'rgba4'`    | `gl.RGBA4`        | Renderbuffer |                                                                                                                           |
+| `'rgb565'`   | `gl.RGB565`       | Renderbuffer |                                                                                                                           |
+| `'rgb5 a1'`  | `gl.RGB5_A1`      | Renderbuffer |                                                                                                                           |
+| `'rgb16f'`   | `gl.RGB16F`       | Renderbuffer | only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)     |
+| `'rgba16f'`  | `gl.RGBA16F`      | Renderbuffer | only if [EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)     |
+| `'rgba32f'`  | `gl.RGBA32F`      | Renderbuffer | only if [WEBGL_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/) supported |
+| `'srgba'`    | `gl.SRGB8_ALPHA8` | Renderbuffer | only if [EXT_sRGB](https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/) supported                                 |
 
-| Color type | Description |
-|------------|-------------|
-| `'uint8'` | `gl.UNSIGNED_BYTE` |
-| `'half float'` | 16 bit float, requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/)  |
-| `'float'` | 32 bit float, requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/) |
+| Color type     | Description                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `'uint8'`      | `gl.UNSIGNED_BYTE`                                                                                                         |
+| `'half float'` | 16 bit float, requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/) |
+| `'float'`      | 32 bit float, requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/)           |
 
 **Notes**
 
-* If `color` is not specified, then color attachments are created automatically
-* Instead of passing width/height, it is also possible to pass in `shape` to the framebuffer constructor.
+-   If `color` is not specified, then color attachments are created automatically
+-   Instead of passing width/height, it is also possible to pass in `shape` to the framebuffer constructor.
 
 **Relevant WebGL APIs**
 
-* [`gl.createFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateFramebuffer.xml)
-* [`gl.deleteFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteFramebuffer.xml)
-* [`gl.framebufferRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFramebufferRenderbuffer.xml)
-* [`gl.framebufferTexture2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFramebufferTexture2D.xml)
-* [`gl.bindFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindFramebuffer.xml)
+-   [`gl.createFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateFramebuffer.xml)
+-   [`gl.deleteFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteFramebuffer.xml)
+-   [`gl.framebufferRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFramebufferRenderbuffer.xml)
+-   [`gl.framebufferTexture2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFramebufferTexture2D.xml)
+-   [`gl.bindFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindFramebuffer.xml)
 
 #### Framebuffer update
 
@@ -2016,9 +2169,9 @@ fbo.destroy()
 
 **Relevant WebGL APIs**
 
-* [`gl.deleteFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteFramebuffer.xml)
+-   [`gl.deleteFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteFramebuffer.xml)
 
----------------------------------------
+* * *
 
 ### Cubic frame buffers
 
@@ -2035,31 +2188,31 @@ var cubeAlt = regl.framebufferCube({
 })
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `radius` | The size of the cube buffer |
-| `color` | The color buffer attachment |
-| `colorFormat` | Format of color buffer to create |
-| `colorType` | Type of color buffer |
-| `colorCount` | Number of color attachments |
-| `depth` | Depth buffer attachment |
-| `stencil` | Stencil buffer attachment |
-| `depthStencil` | Depth-stencil attachment |
+| Parameter      | Description                      |
+| -------------- | -------------------------------- |
+| `radius`       | The size of the cube buffer      |
+| `color`        | The color buffer attachment      |
+| `colorFormat`  | Format of color buffer to create |
+| `colorType`    | Type of color buffer             |
+| `colorCount`   | Number of color attachments      |
+| `depth`        | Depth buffer attachment          |
+| `stencil`      | Stencil buffer attachment        |
+| `depthStencil` | Depth-stencil attachment         |
 
 | Color format | Description | Attachment |
-|--------------|-------------|------------|
-| `'rgba'` | `gl.RGBA` | Texture |
+| ------------ | ----------- | ---------- |
+| `'rgba'`     | `gl.RGBA`   | Texture    |
 
-| Color type | Description |
-|------------|-------------|
-| `'uint8'` | `gl.UNSIGNED_BYTE` |
-| `'half float'` | 16 bit float, requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/)  |
-| `'float'` | 32 bit float, requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/) |
+| Color type     | Description                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `'uint8'`      | `gl.UNSIGNED_BYTE`                                                                                                         |
+| `'half float'` | 16 bit float, requires [OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/) |
+| `'float'`      | 32 bit float, requires [OES_texture_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_float/)           |
 
 **Notes**
 
-* The specified depth/stencil/depth-stencil attachment will be reused
-for all 6 cube faces.
+-   The specified depth/stencil/depth-stencil attachment will be reused
+    for all 6 cube faces.
 
 #### Cube framebuffer update
 
@@ -2082,13 +2235,13 @@ fboCube.resize(16)
 fboCube.destroy()
 ```
 
----------------------------------------
+* * *
 
 ## Other tasks
 
 Other than draw commands and resources, there are a few miscellaneous parts of the WebGL API which REGL wraps for completeness.
 
----------------------------------------
+* * *
 
 ### Clear the draw buffer
 
@@ -2102,22 +2255,22 @@ regl.clear({
 })
 ```
 
-| Property | Description |
-|----------|-------------|
-| `color` | Sets the clear color |
-| `depth` | Sets the clear depth value |
+| Property  | Description                  |
+| --------- | ---------------------------- |
+| `color`   | Sets the clear color         |
+| `depth`   | Sets the clear depth value   |
 | `stencil` | Sets the clear stencil value |
 
 If an option is not present, then the corresponding buffer is not cleared
 
 **Relevant WebGL APIs**
 
-* [`gl.clearColor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClearColor.xml)
-* [`gl.clearDepth`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClearDepth.xml)
-* [`gl.clearStencil`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClearStencil.xml)
-* [`gl.clear`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClear.xml)
+-   [`gl.clearColor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClearColor.xml)
+-   [`gl.clearDepth`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClearDepth.xml)
+-   [`gl.clearStencil`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClearStencil.xml)
+-   [`gl.clear`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClear.xml)
 
----------------------------------------
+* * *
 
 ### Reading pixels
 
@@ -2153,29 +2306,29 @@ regl({framebuffer: fbo})(() => {
 })
 ```
 
-| Property | Description | Default |
-|----------|-------------|---------|
-| `data` | An optional `ArrayBufferView` which gets the result of reading the pixels | `null` |
-| `x` | The x-offset of the upper-left corner of the rectangle in pixels | `0` |
-| `y` | The y-offset of the upper-left corner of the rectangle in pixels | `0` |
-| `width` | The width of the rectangle in pixels | Current framebuffer width |
-| `height` | The height of the rectangle in pixels | Current framebuffer height |
+| Property | Description                                                               | Default                    |
+| -------- | ------------------------------------------------------------------------- | -------------------------- |
+| `data`   | An optional `ArrayBufferView` which gets the result of reading the pixels | `null`                     |
+| `x`      | The x-offset of the upper-left corner of the rectangle in pixels          | `0`                        |
+| `y`      | The y-offset of the upper-left corner of the rectangle in pixels          | `0`                        |
+| `width`  | The width of the rectangle in pixels                                      | Current framebuffer width  |
+| `height` | The height of the rectangle in pixels                                     | Current framebuffer height |
 
 **Notes**
 
-* In order to read pixels from the drawing buffer, you must create
-  your webgl context with `preserveDrawingBuffer` set to `true`.  If
-  this is not set, then `regl.read` will throw an exception.
+-   In order to read pixels from the drawing buffer, you must create
+    your webgl context with `preserveDrawingBuffer` set to `true`.  If
+    this is not set, then `regl.read` will throw an exception.
 
-* You can only read pixels from a framebuffer of type `'uint8'` or
-  `'float'`. Furthermore, it is not possible to read from a renderbuffer.
+-   You can only read pixels from a framebuffer of type `'uint8'` or
+    `'float'`. Furthermore, it is not possible to read from a renderbuffer.
 
 **Relevant WebGL APIs**
 
-* [`gl.pixelStorei`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
-* [`gl.readPixels`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glReadPixels.xml)
+-   [`gl.pixelStorei`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml)
+-   [`gl.readPixels`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glReadPixels.xml)
 
----------------------------------------
+* * *
 
 ### Per-frame callbacks
 
@@ -2196,7 +2349,7 @@ tick.cancel()
 
 It is possible to manage framecallbacks manually, however before any loop it is essential to call `regl.poll()` which updates all timers and viewports.
 
----------------------------------------
+* * *
 
 ### Extensions
 
@@ -2227,71 +2380,71 @@ For more information on WebGL extensions, see the [WebGL extension registry](htt
 
 **Relevant WebGL APIs**
 
-* [WebGL Extension Registry](https://www.khronos.org/registry/webgl/extensions/)
-* `gl.getExtension`
-* `gl.getSupportedExtensions`
+-   [WebGL Extension Registry](https://www.khronos.org/registry/webgl/extensions/)
+-   `gl.getExtension`
+-   `gl.getSupportedExtensions`
 
----------------------------------------
+* * *
 
 ### Device capabilities and limits
 
 regl exposes info about the WebGL context limits and capabilities via the `regl.limits` object.  The following properties are supported,
 
-| Property | Description |
-|----------|-------------|
-| `colorBits` | An array of bits depths for the red, green, blue and alpha channels |
-| `depthBits` | Bit depth of drawing buffer |
-| `stencilBits` | Bit depth of stencil buffer |
-| `subpixelBits` | `gl.SUBPIXEL_BITS` |
-| `extensions` | A list of all supported extensions |
-| `maxAnisotropic` | Maximum number of anisotropic filtering samples |
-| `maxDrawbuffers` | Maximum number of draw buffers |
-| `maxColorAttachments` | Maximum number of color attachments |
-| `pointSizeDims` | `gl.ALIASED_POINT_SIZE_RANGE` |
-| `lineWidthDims` | `gl.ALIASED_LINE_WIDTH_RANGE` |
-| `maxViewportDims` | `gl.MAX_VIEWPORT_DIMS` |
-| `maxCombinedTextureUnits` | `gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS` |
-| `maxCubeMapSize` | `gl.MAX_CUBE_MAP_TEXTURE_SIZE` |
-| `maxRenderbufferSize` | `gl.MAX_RENDERBUFFER_SIZE` |
-| `maxTextureUnits` | `gl.MAX_TEXTURE_IMAGE_UNITS` |
-| `maxTextureSize` | `gl.MAX_TEXTURE_SIZE` |
-| `maxAttributes` | `gl.MAX_VERTEX_ATTRIBS` |
-| `maxVertexUniforms` | `gl.MAX_VERTEX_UNIFORM_VECTORS` |
-| `maxVertexTextureUnits` | `gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS` |
-| `maxVaryingVectors` | `gl.MAX_VARYING_VECTORS` |
-| `maxFragmentUniforms` | `gl.MAX_FRAGMENT_UNIFORM_VECTORS` |
-| `glsl` | `gl.SHADING_LANGUAGE_VERSION` |
-| `renderer` | `gl.RENDERER` |
-| `vendor` | `gl.VENDOR` |
-| `version` | `gl.VERSION` |
+| Property                  | Description                                                         |
+| ------------------------- | ------------------------------------------------------------------- |
+| `colorBits`               | An array of bits depths for the red, green, blue and alpha channels |
+| `depthBits`               | Bit depth of drawing buffer                                         |
+| `stencilBits`             | Bit depth of stencil buffer                                         |
+| `subpixelBits`            | `gl.SUBPIXEL_BITS`                                                  |
+| `extensions`              | A list of all supported extensions                                  |
+| `maxAnisotropic`          | Maximum number of anisotropic filtering samples                     |
+| `maxDrawbuffers`          | Maximum number of draw buffers                                      |
+| `maxColorAttachments`     | Maximum number of color attachments                                 |
+| `pointSizeDims`           | `gl.ALIASED_POINT_SIZE_RANGE`                                       |
+| `lineWidthDims`           | `gl.ALIASED_LINE_WIDTH_RANGE`                                       |
+| `maxViewportDims`         | `gl.MAX_VIEWPORT_DIMS`                                              |
+| `maxCombinedTextureUnits` | `gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS`                               |
+| `maxCubeMapSize`          | `gl.MAX_CUBE_MAP_TEXTURE_SIZE`                                      |
+| `maxRenderbufferSize`     | `gl.MAX_RENDERBUFFER_SIZE`                                          |
+| `maxTextureUnits`         | `gl.MAX_TEXTURE_IMAGE_UNITS`                                        |
+| `maxTextureSize`          | `gl.MAX_TEXTURE_SIZE`                                               |
+| `maxAttributes`           | `gl.MAX_VERTEX_ATTRIBS`                                             |
+| `maxVertexUniforms`       | `gl.MAX_VERTEX_UNIFORM_VECTORS`                                     |
+| `maxVertexTextureUnits`   | `gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS`                                 |
+| `maxVaryingVectors`       | `gl.MAX_VARYING_VECTORS`                                            |
+| `maxFragmentUniforms`     | `gl.MAX_FRAGMENT_UNIFORM_VECTORS`                                   |
+| `glsl`                    | `gl.SHADING_LANGUAGE_VERSION`                                       |
+| `renderer`                | `gl.RENDERER`                                                       |
+| `vendor`                  | `gl.VENDOR`                                                         |
+| `version`                 | `gl.VERSION`                                                        |
 
 **Relevant WebGL APIs**
 
-* [`gl.getParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetParameter.xml)
+-   [`gl.getParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetParameter.xml)
 
----------------------------------------
+* * *
 
 ### Performance metrics
 
 `regl` tracks several metrics for performance monitoring.  These can be read using the `regl.stats` object:
 
-| Metric | Meaning |
-|--------|---------|
-| `bufferCount` | The number of array buffers currently allocated |
-| `elementsCount` | The number of element buffers currently allocated |
-| `framebufferCount` | The number of framebuffers currently allocated |
-| `shaderCount` | The number of shaders currently allocated |
-| `textureCount` | The number of textures currently allocated |
-| `cubeCount` | The number of cube maps currently allocated |
-| `renderbufferCount` | The number of renderbuffers currently allocated |
-| `getTotalTextureSize()` | The total amount of memory allocated for textures and cube maps |
-| `getTotalBufferSize()` | The total amount of memory allocated for array buffers and element buffers |
-| `getTotalRenderbufferSize()` | The total amount of memory allocated for renderbuffers |
-| `getMaxUniformsCount()` | The maximum number of uniforms in any shader |
-| `getMaxAttributesCount()` | The maximum number of attributes in any shader |
-| `maxTextureUnits()` | The maximum number of texture units used |
+| Metric                       | Meaning                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `bufferCount`                | The number of array buffers currently allocated                            |
+| `elementsCount`              | The number of element buffers currently allocated                          |
+| `framebufferCount`           | The number of framebuffers currently allocated                             |
+| `shaderCount`                | The number of shaders currently allocated                                  |
+| `textureCount`               | The number of textures currently allocated                                 |
+| `cubeCount`                  | The number of cube maps currently allocated                                |
+| `renderbufferCount`          | The number of renderbuffers currently allocated                            |
+| `getTotalTextureSize()`      | The total amount of memory allocated for textures and cube maps            |
+| `getTotalBufferSize()`       | The total amount of memory allocated for array buffers and element buffers |
+| `getTotalRenderbufferSize()` | The total amount of memory allocated for renderbuffers                     |
+| `getMaxUniformsCount()`      | The maximum number of uniforms in any shader                               |
+| `getMaxAttributesCount()`    | The maximum number of attributes in any shader                             |
+| `maxTextureUnits()`          | The maximum number of texture units used                                   |
 
----------------------------------------
+* * *
 
 ### Clean up
 
@@ -2301,7 +2454,7 @@ When a `regl` context is no longer needed, it can be destroyed releasing all ass
 regl.destroy()
 ```
 
----------------------------------------
+* * *
 
 ### Context loss
 
@@ -2309,7 +2462,7 @@ regl.destroy()
 
 **TODO**
 
----------------------------------------
+* * *
 
 ### Unsafe escape hatch
 
@@ -2329,7 +2482,7 @@ regl._refresh()
 
 Note that you must call `regl._refresh()` if you have changed the WebGL state.
 
----------------------------------------
+* * *
 
 ## Tips
 
@@ -2341,12 +2494,12 @@ The following are some random tips for writing WebGL programs.  Some are regl sp
 
 ### Preallocate memory
 
-* Reuse property objects passed to commands to avoid garbage collection
+-   Reuse property objects passed to commands to avoid garbage collection
 
 ### Debug vs release
 
-* Debug mode inserts many checks
-* Compiling in release mode removes these assertions, improves performance and reduces bundle size
+-   Debug mode inserts many checks
+-   Compiling in release mode removes these assertions, improves performance and reduces bundle size
 
 ### Profiling tips
 

--- a/API.md
+++ b/API.md
@@ -116,7 +116,7 @@ const drawTriangle = regl({
 })
 ```
 
-To execute a command you call it just like you would any function,
+To run a command you call it just like you would any function,
 
 ```javascript
 drawTriangle()
@@ -126,43 +126,43 @@ drawTriangle()
 
 ### Executing commands
 
-There are 3 ways to execute a command,
+There are 3 ways to run a command,
 
 #### One-shot rendering
 
-In one shot rendering the command is executed once and immediately,
+In one shot rendering the command runs once immediately,
 
 ```javascript
-// Executes command immediately with no arguments
+// Runs command immediately with no arguments
 command()
 
-// Executes a command using the specified arguments
+// Runs a command using the specified arguments
 command(props)
 ```
 
 #### Batch rendering
 
-A command can also be executed multiple times by passing a non-negative integer or an array as the first argument.  The `batchId` is initially `0` and incremented for each executed,
+A command can also run multiple times by passing a non-negative integer or an array as the first argument.  The `batchId` is initially `0` and incremented for each iteration,
 
 ```javascript
-// Executes the command `count`-times
+// Runs the command `count`-times
 command(count)
 
-// Executes the command once for each args
+// Runs the command once for each args
 command([props0, props1, props2, ..., propsn])
 ```
 
 #### Scoped commands
 
-Commands can be nested using scoping.  If the argument to the command is a function then the command is evaluated and the state variables are saved as the defaults for all commands executed within its scope,
+Commands can be nested using scoping.  If the argument to the command is a function then the command is evaluated and the state variables are saved as the defaults for all commands within its scope,
 
 ```javascript
 command(function (context) {
-  // ... execute sub commands
+  // ... run sub commands
 })
 
 command(props, function (context) {
-  // ... execute sub commands
+  // ... run sub commands
 })
 ```
 
@@ -243,7 +243,7 @@ var drawSpinningStretchyTriangle = regl({
 })
 ```
 
-To execute a draw command with dynamic arguments we pass it a configuration object as the first argument,
+To run a draw command with dynamic arguments we pass it a configuration object as the first argument,
 
 ```javascript
 // Draws one spinning triangle
@@ -336,7 +336,7 @@ The most common way to pass data into regl is via props.  The props for a render
 
 #### `this`
 
-While `regl` strives to provide a stateless API, there are a few cases where it can be useful to cache state locally to a specific command.  One way to achieve this is to use objects.  When a regl command is executed as a member function of an object, the `this` parameter is set to the object on which it was called and is passed to all computed parameters. For example, this shows how to use regl to create a simple reusable mesh object,
+While `regl` strives to provide a stateless API, there are a few cases where it can be useful to cache state locally to a specific command.  One way to achieve this is to use objects.  When a regl command is run as a member function of an object, the `this` parameter is set to the object on which it was called and is passed to all computed parameters. For example, this shows how to use regl to create a simple reusable mesh object,
 
 ```javascript
 // First we create a constructor
@@ -634,7 +634,7 @@ var command = regl({
 
 #### Profiling
 
-`regl` can optionally instrument commands to track profiling data.  This is enabled/disabled by setting the `profile` flag on each command.
+`regl` can optionally instrument commands to track profiling data.  This is toggled by setting the `profile` flag on each command.
 
 ```javascript
 var myScope = regl({
@@ -1422,7 +1422,7 @@ myElements.destroy()
 
 #### Texture constructor
 
-There are many ways to upload data to a texture in WebGL.  As with drawing commands, regl consolidates all of these crazy configuration parameters into one function.  Here are some examples of how to create a texture,
+There are many ways to upload data to a texture in WebGL.  As with drawing commands, regl consolidates all of these configuration parameters into one function.  Here are some examples of how to create a texture,
 
 ```javascript
 // From size parameters
@@ -1679,7 +1679,7 @@ Where,
 
 * `data` is an image data object, similar to the arguments for the texture constructor
 * `x, y` is the offset of the subimage within the texture (default `0,0`)
-* `level` is the miplevel to execute the subimage within (default `0`)
+* `level` is the miplevel to run the subimage within (default `0`)
 
 **Relevant WebGL APIs**
 
@@ -2182,7 +2182,7 @@ regl({framebuffer: fbo})(() => {
 `regl` also provides a common wrapper over `requestAnimationFrame` and `cancelAnimationFrame` that integrates gracefully with context loss events.  `regl.frame()` also calls `gl.flush` and drains several internal buffers, so you should try to do all your rendering to the drawing buffer within the frame callback.
 
 ```javascript
-// Hook a callback to execute each frame
+// Hook a callback to run each frame
 var tick = regl.frame(function (context) {
 
   // context is the default state of the regl context variables

--- a/API.md
+++ b/API.md
@@ -1,94 +1,25 @@
 # REGL API
 
-* [Initialization](#initialization)
-    - [As a fullscreen canvas](#as-a-fullscreen-canvas)
-    - [From a container div](#from-a-container-div)
-    - [From a canvas](#from-a-canvas)
-    - [From a WebGL context](#from-a-webgl-context)
-  + [Initialization options](#initialization-options)
-* [Commands](#commands)
-  + [Executing commands](#executing-commands)
-    - [One-shot rendering](#one-shot-rendering)
-    - [Batch rendering](#batch-rendering)
-    - [Scoped commands](#scoped-commands)
-  + [Inputs](#inputs)
-    - [Context](#context)
-    - [Props](#props)
-    - [`this`](#this)
-  + [Parameters](#parameters)
-    - [Shaders](#shaders)
-    - [Uniforms](#uniforms)
-    - [Attributes](#attributes)
-    - [Drawing](#drawing)
-    - [Render target](#render-target)
-    - [Profiling](#profiling)
-    - [Depth buffer](#depth-buffer)
-    - [Blending](#blending)
-    - [Stencil](#stencil)
-    - [Polygon offset](#polygon-offset)
-    - [Culling](#culling)
-    - [Front face](#front-face)
-    - [Dithering](#dithering)
-    - [Line width](#line-width)
-    - [Color mask](#color-mask)
-    - [Sample coverage](#sample-coverage)
-    - [Scissor](#scissor)
-    - [Viewport](#viewport)
-* [Resources](#resources)
-  + [Buffers](#buffers)
-    - [Constructor](#constructor)
-    - [Update](#update)
-    - [Destroy](#destroy)
-  + [Elements](#elements)
-    - [Constructor](#constructor-1)
-    - [Update](#update-1)
-    - [Destroy](#destroy-1)
-  + [Textures](#textures)
-    - [Constructor](#constructor-2)
-    - [Update](#update-2)
-    - [Destroy](#destroy-2)
-  + [Cube maps](#cube-maps)
-    - [Constructor](#constructor-3)
-    - [Update](#update-3)
-    - [Destroy](#destroy-3)
-  + [Render buffers](#render-buffers)
-    - [Constructor](#constructor-4)
-    - [Update](#update-4)
-    - [Destroy](#destroy-4)
-  + [Framebuffers](#framebuffers)
-    - [Constructor](#constructor-5)
-    - [Update](#update-5)
-    - [Destroy](#destroy-5)
-  + [Cubic frame buffers](#cubic-frame-buffers)
-    - [Constructor](#constructor-6)
-    - [Update](#update-6)
-    - [Destroy](#destroy-6)
-* [Other features](#other-features)
-  + [Clear the draw buffer](#clear-the-draw-buffer)
-  + [Reading pixels](#reading-pixels)
-  + [Per-frame callbacks](#per-frame-callbacks)
-  + [Device capabilities and limits](#device-capabilities-and-limits)
-  + [Performance metrics](#performance-metrics)
-  + [Clean up](#clean-up)
-  + [Context loss](#context-loss)
-  + [Unsafe escape hatch](#unsafe-escape-hatch)
-* [Tips](#tips)
-  + [Reuse resources (buffers, elements, textures, etc.)](#reuse-resources--buffers--elements--textures--etc-)
-  + [Preallocate memory](#preallocate-memory)
-  + [Debug vs release](#debug-vs-release)
-  + [Context loss mitigation](#context-loss-mitigation)
+## Table of contents
 
 ---------------------------------------
+
 ## Initialization
 
+### Quick start
+
 #### As a fullscreen canvas
+
 By default calling `module.exports` on the `regl` package creates a full screen canvas element and WebGLRenderingContext.
 
 ```javascript
 var regl = require('regl')()
 ```
 
+This canvas will dynamically resize whenever the window changes shape.  For most quick demos this is an easy way to get started using `regl`.
+
 #### From a container div
+
 Alternatively passing a container element as the first argument appends the generated canvas to its children.
 
 ```javascript
@@ -102,6 +33,7 @@ var regl = require('regl')({
 ```
 
 #### From a canvas
+
 If the first argument is an HTMLCanvasElement, then `regl` will use this canvas to create a new WebGLRenderingContext that it renders into.
 
 ```javascript
@@ -115,6 +47,7 @@ var regl = require('regl')({
 ```
 
 #### From a WebGL context
+
 Finally, if the first argument is a WebGLRenderingContext, then `regl` will just use this context without touching the DOM at all.
 
 ```javascript
@@ -127,7 +60,9 @@ var regl = require('regl')({
 })
 ```
 
-Note that this form is compatible with [`headless-gl`](https://github.com/stackgl/headless-gl) and can be used to do offscreen rendering in node.js. For example,
+#### From a headless context
+
+The above form can also be used to run `regl` headlessly by combining it with the [`headless-gl`](https://github.com/stackgl/headless-gl) package.  This works in node.js, electron and the browser.
 
 ```javascript
 //Creates a headless 256x256 regl instance
@@ -136,9 +71,8 @@ var regl = require('regl')(require('gl')(256, 256))
 
 ### All initialization options
 
-
 | Options | Meaning |
-|---------|---------|
+| ------- | ------- |
 | `gl` | A reference to a WebGL rendering context. (Default created from canvas) |
 | `canvas` | A reference to an HTML canvas element. (Default created and appending to container) |
 | `container` | A container element which regl inserts a canvas into. (Default `document.body`) |
@@ -156,6 +90,7 @@ var regl = require('regl')(require('gl')(256, 256))
 * `onDone` is called
 
 ---------------------------------------
+
 ## Commands
 
 *Draw commands* are the fundamental abstraction in `regl`.  A draw command wraps up all of the WebGL state associated with a draw call (either `drawArrays` or `drawElements`) and packages it into a single reusable function. For example, here is a command that draws a triangle,
@@ -188,10 +123,13 @@ drawTriangle()
 ```
 
 ---------------------------------------
+
 ### Executing commands
+
 There are 3 ways to execute a command,
 
 #### One-shot rendering
+
 In one shot rendering the command is executed once and immediately,
 
 ```javascript
@@ -203,6 +141,7 @@ command(props)
 ```
 
 #### Batch rendering
+
 A command can also be executed multiple times by passing a non-negative integer or an array as the first argument.  The `batchId` is initially `0` and incremented for each executed,
 
 ```javascript
@@ -214,6 +153,7 @@ command([props0, props1, props2, ..., propsn])
 ```
 
 #### Scoped commands
+
 Commands can be nested using scoping.  If the argument to the command is a function then the command is evaluated and the state variables are saved as the defaults for all commands executed within its scope,
 
 ```javascript
@@ -227,7 +167,9 @@ command(props, function (context) {
 ```
 
 ---------------------------------------
+
 ### Inputs
+
 Inputs to `regl` commands can come from one of three sources,
 
 * Context: Context variables are not used directly in commands, but can be passed into
@@ -328,6 +270,7 @@ drawSpinningStretchyTriangle([
 ```
 
 #### Context
+
 Context variables in `regl` are computed before any other parameters and can also be passed from a scoped command to any sub-commands.  `regl` defines the following default context variables:
 
 | Name | Description |
@@ -388,9 +331,11 @@ setupCamera({
 ```
 
 #### Props
+
 The most common way to pass data into regl is via props.  The props for a render command are declared
 
 #### `this`
+
 While `regl` strives to provide a stateless API, there are a few cases where it can be useful to cache state locally to a specific command.  One way to achieve this is to use objects.  When a regl command is executed as a member function of an object, the `this` parameter is set to the object on which it was called and is passed to all computed parameters. For example, this shows how to use regl to create a simple reusable mesh object,
 
 ```javascript
@@ -464,10 +409,13 @@ teapotMesh.draw({
 ```
 
 ---------------------------------------
+
 ### Parameters
+
 The input to a command declaration is a complete description of the WebGL state machine in the form of an object.  The properties of this object are parameters which specify how values in the WebGL state machine are to be computed.
 
 ---------------------------------------
+
 #### Shaders
 
 Each draw command can specify the source code for a vertex and/or fragment shader,
@@ -506,7 +454,9 @@ var command = regl({
 * [`gl.useProgram`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glUseProgram.xml)
 
 ---------------------------------------
+
 #### Uniforms
+
 Uniform variables are specified in the `uniforms` block of the command.  For example,
 
 ```javascript
@@ -537,6 +487,7 @@ var command = regl({
 ```
 
 **Notes**
+
 * To specify uniforms in nested structs use the fully qualified path with dot notation
 * Matrix uniforms are specified as flat length n^2 arrays without transposing
 
@@ -546,7 +497,9 @@ var command = regl({
 * [`gl.uniform`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glUniform.xml)
 
 ---------------------------------------
+
 #### Attributes
+
 ```javascript
 var command = regl({
   // ...
@@ -594,6 +547,7 @@ Each attribute can have any of the following optional properties,
 | `divisor` | Sets `gl.vertexAttribDivisorANGLE` | `0` * |
 
 **Notes**
+
 * Attribute size is inferred from the shader vertex attribute if not specified
 * If a buffer is passed for an attribute then all pointer info is inferred
 * If the arguments to `regl.buffer` are passed, then a buffer is constructed
@@ -609,6 +563,7 @@ Each attribute can have any of the following optional properties,
 * [`gl.enableVertexAttribArray`, `gl.disableVertexAttribArray`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDisableVertexAttribArray.xml)
 
 ---------------------------------------
+
 #### Drawing
 
 ```javascript
@@ -654,7 +609,9 @@ var command = regl({
 * [`gl.drawElementsInstancedANGLE`](https://www.opengl.org/sdk/docs/man4/html/glDrawElementsInstanced.xhtml)
 
 ---------------------------------------
+
 #### Render target
+
 A `regl.framebuffer` object may also be specified to allow for rendering to offscreen locations.
 
 ```javascript
@@ -674,7 +631,9 @@ var command = regl({
 * [`gl.bindFramebuffer`](https://www.opengl.org/sdk/docs/man4/html/glBindFramebuffer.xhtml)
 
 ---------------------------------------
+
 #### Profiling
+
 `regl` can optionally instrument commands to track profiling data.  This is enabled/disabled by setting the `profile` flag on each command.
 
 ```javascript
@@ -714,7 +673,9 @@ The following stats are tracked for each command in the `.stats` property:
 * [EXT_disjoint_timer_query](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/)
 
 ---------------------------------------
+
 #### Depth buffer
+
 All state relating to the depth buffer is stored in the `depth` field of the command.  For example,
 
 ```javascript
@@ -740,6 +701,7 @@ var command = regl({
 | `func` | Sets `gl.depthFunc`. See table below for possible values | `'less'` |
 
 **Notes**
+
 * `depth.func` can take on the possible values
 
 | Value | Description |
@@ -760,7 +722,9 @@ var command = regl({
 * [`gl.depthRange`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDepthRangef.xml)
 
 ---------------------------------------
+
 #### Blending
+
 Blending information is stored in the `blend` field,
 
 ```javascript
@@ -794,6 +758,7 @@ var command = regl({
 | `color` | Sets `gl.blendColor` | `[0, 0, 0, 0]` |
 
 **Notes**
+
 * `equation` can be either a string or an object with the fields `{rgb, alpha}`.  The former corresponds to `gl.blendEquation` and the latter to `gl.blendEquationSeparate`
 * The fields of `equation` can take on the following values
 
@@ -834,6 +799,7 @@ var command = regl({
 * [`gl.blendColor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBlendColor.xml)
 
 ---------------------------------------
+
 #### Stencil
 
 Example:
@@ -877,9 +843,11 @@ var command = regl({
 **Notes**
 
 * `func` is an object which configures the stencil test function. It has 3 properties,
-    + `cmp` which is the comparison function
-    + `ref` which is the reference value
-    + `mask` which is the comparison mask
+
+  * `cmp` which is the comparison function
+  * `ref` which is the reference value
+  * `mask` which is the comparison mask
+
 * `func.cmp` is a comparison operator which takes one of the following values,
 
 | Value | Description |
@@ -894,9 +862,11 @@ var command = regl({
 | `'!=', 'notequal'` | `gl.NOTEQUAL` |
 
 * `opFront` and `opBack` specify the stencil op.  Each is an object which takes the following parameters:
-    + `fail`, the stencil op which is applied when the stencil test fails
-    + `zfail`, the stencil op which is applied when the stencil test passes and the depth test fails
-    + `pass`, the stencil op which is applied when both stencil and depth tests pass
+
+  * `fail`, the stencil op which is applied when the stencil test fails
+  * `zfail`, the stencil op which is applied when the stencil test passes and the depth test fails
+  * `pass`, the stencil op which is applied when both stencil and depth tests pass
+
 * Values for `opFront.fail`, `opFront.zfail`, etc. can come from the following table
 
 | Stencil Op | Description |
@@ -917,6 +887,7 @@ var command = regl({
 * [`gl.stencilOpSeparate`](http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glStencilOpSeparate.xml)
 
 ---------------------------------------
+
 #### Polygon offset
 
 Polygon offsetting behavior can be controlled using the `polygonOffset` field,
@@ -947,7 +918,9 @@ var command = regl({
 * [`gl.polygonOffset`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glPolygonOffset.xml)
 
 ---------------------------------------
+
 #### Culling
+
 Example,
 
 ```javascript
@@ -982,7 +955,9 @@ var command = regl({
 * [`gl.cullFace`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCullFace.xml)
 
 ---------------------------------------
+
 #### Front face
+
 Example,
 
 ```javascript
@@ -1013,7 +988,9 @@ var command = regl({
 * [`gl.frontFace`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFrontFace.xml)
 
 ---------------------------------------
+
 #### Dithering
+
 Example,
 
 ```javascript
@@ -1031,7 +1008,9 @@ var command = regl({
 | `dither` | Toggles `gl.DITHER` | `false` |
 
 ---------------------------------------
+
 #### Line width
+
 Example,
 
 ```javascript
@@ -1053,7 +1032,9 @@ var command = regl({
 * [`gl.lineWidth`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glLineWidth.xml)
 
 ---------------------------------------
+
 #### Color mask
+
 Example,
 
 ```javascript
@@ -1075,7 +1056,9 @@ var command = regl({
 * [`gl.colorMask`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
 
 ---------------------------------------
+
 #### Sample coverage
+
 Example,
 
 ```javascript
@@ -1106,7 +1089,9 @@ var command = regl({
 * [`gl.sampleCoverage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
 
 ---------------------------------------
+
 #### Scissor
+
 Example,
 
 ```javascript
@@ -1133,18 +1118,22 @@ var command = regl({
 | `box` | Sets `gl.scissor` | `{}` |
 
 **Notes**
+
 * `box` is the shape of the scissor region, it takes the following parameters
-    + `x` is the left coordinate of the box, default `0`
-    + `y` is the top coordiante of the box, default `0`
-    + `w` is the width of the box, default fbo width - `x`
-    + `h` is the height of the box, default fbo height - `y`
+
+  * `x` is the left coordinate of the box, default `0`
+  * `y` is the top coordiante of the box, default `0`
+  * `width` is the width of the box, default fbo width - `x`
+  * `height` is the height of the box, default fbo height - `y`
 
 **Relevant WebGL APIs**
 
 * [`gl.scissor`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glScissor.xml)
 
 ---------------------------------------
+
 #### Viewport
+
 Example,
 
 ```javascript
@@ -1176,14 +1165,18 @@ var command = regl({
 * [`gl.viewport`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glViewport.xml)
 
 ---------------------------------------
+
 ## Resources
+
 Besides commands, the other major component of regl are resources.  Resources are GPU resident objects which are managed explicitly by the programmer.  Each resource follows a the same life cycle of create/read/update/delete.
 
 ---------------------------------------
+
 ### Buffers
+
 `regl.buffer` wraps WebGL array buffer objects.
 
-#### Constructor
+#### Buffer constructor
 
 ```javascript
 // Creates an empty length 100 buffer
@@ -1223,8 +1216,8 @@ var positionBuffer = regl.buffer([
 * [`gl.createBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCreateBuffer.xml)
 * [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 
+#### Buffer update
 
-#### Update
 To reinitialize a buffer in place, we can call the buffer as a function:
 
 ```javascript
@@ -1247,7 +1240,8 @@ The arguments to the update pathway are the same as the constructor and the retu
 
 * [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 
-##### In place update
+##### Buffer subdata
+
 For performance reasons we may sometimes want to update just a portion of
 We can also update a portion of the buffer using the `subdata` method.  This can be useful if you are dealing with frequently changing or streaming vertex data.  Here is an example:
 
@@ -1281,8 +1275,8 @@ myBuffer.subdata([[7, 8], [9, 10]], 8)
 
 * [`gl.bufferSubData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferSubData.xml)
 
+#### Buffer destructor
 
-#### Destroy
 Calling `.destroy()` on a buffer releases all resources associated to the buffer:
 
 ```javascript
@@ -1295,7 +1289,7 @@ myBuffer.destroy()
 
 * [`gl.deleteBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteBuffer.xml)
 
-#### Profiling
+#### Profiling info
 
 The following stats are tracked for each buffer in the `.stats` property:
 
@@ -1304,10 +1298,12 @@ The following stats are tracked for each buffer in the `.stats` property:
 | `size` | The size of the buffer in bytes |
 
 ---------------------------------------
+
 ### Elements
+
 `regl.elements` wraps WebGL element array buffer objects.  Each `regl.elements` object stores a buffer object as well as the primitive type and vertex count.
 
-#### Constructor
+#### Element constructor
 
 ```javascript
 var triElements = regl.elements([
@@ -1360,8 +1356,8 @@ var starElements = regl.elements({
 * [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 * [`gl.drawElements`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDrawElements.xml)
 
+#### Element update
 
-#### Update
 As in the case of buffers, calling an element buffer as a function reinitializes an element buffer in place.  The arguments are the same as for the constructor.  For example:
 
 ```javascript
@@ -1381,7 +1377,8 @@ myElements({
 
 * [`gl.bufferData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml)
 
-##### In-place update
+##### Element subdata
+
 Again like buffers it is possible to preallocate an element buffer and update regions of the elements using the `subdata` command.
 
 ```javascript
@@ -1404,7 +1401,7 @@ myElements.subdata(
 
 * [`gl.bufferSubData`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferSubData.xml)
 
-#### Destroy
+#### Element destructor
 
 ```javascript
 // First we create an element buffer
@@ -1420,9 +1417,10 @@ myElements.destroy()
 * [`gl.deleteBuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteBuffer.xml)
 
 ---------------------------------------
+
 ### Textures
 
-#### Constructor
+#### Texture constructor
 
 There are many ways to upload data to a texture in WebGL.  As with drawing commands, regl consolidates all of these crazy configuration parameters into one function.  Here are some examples of how to create a texture,
 
@@ -1494,11 +1492,10 @@ A data source from an image can be one of the following types:
 | Canvas | A canvas element |
 | Context 2D | A canvas 2D context |
 
-
 | Property | Description | Default |
 |----------|-------------|---------|
 | `width` | Width of texture | `0` |
-| `height` | Height of texture | `0`
+| `height` | Height of texture | `0` |
 | `mag` | Sets magnification filter (see table) | `'nearest'` |
 | `min` | Sets minification filter (see table) | `'nearest'` |
 | `wrapS` | Sets wrap mode on S axis (see table) | `'repeat'` |
@@ -1630,8 +1627,8 @@ regl.texture({
 * [`gl.generateMipmap`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenerateMipmap.xml)
 * [`gl.hint`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glHint.xml)
 
-https://www.khronos.org/opengles/sdk/docs/man/xhtml/glHint.xml
-#### Update
+#### Texture update
+
 Like buffers, textures can be reinitialized in place.  Calling the texture as a function re-evaluates the constructor and initializes the texture to a new value:
 
 ```javascript
@@ -1658,7 +1655,8 @@ Doing this lets you defer texture construction or reuse texture objects.
 * [`gl.copyTexImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexImage2D.xml)
 * [`gl.generateMipmap`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenerateMipmap.xml)
 
-##### Partial update
+##### Texture subimage
+
 It is also possible to update a subset of a texture contained in a rectangle.  This can be done using the `subimage()` method of the texture:
 
 ```javascript
@@ -1672,10 +1670,13 @@ myTexture.subimage({
 ```
 
 For textures, `subimage` takes 4 arguments:
+
 ```javascript
 texture.subimage(data[, x, y, level])
 ```
+
 Where,
+
 * `data` is an image data object, similar to the arguments for the texture constructor
 * `x, y` is the offset of the subimage within the texture (default `0,0`)
 * `level` is the miplevel to execute the subimage within (default `0`)
@@ -1686,7 +1687,8 @@ Where,
 * [`gl.copyTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexSubImage2D.xml)
 * [`gl.compressedTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexSubImage2D.xml)
 
-##### Resize
+##### Texture resize
+
 Finally, textures can be resized with the `.resize()` method.  Note that this clears the contents of the texture and is not supported by compressed textures.
 
 ```javascript
@@ -1695,7 +1697,8 @@ var texture = regl.texture(5)
 texture.resize(3, 7)
 ```
 
-#### Destroy
+#### Texture destructor
+
 Finally, when a texture is no longer needed it can be released by calling the `destroy()` method:
 
 ```javascript
@@ -1708,8 +1711,7 @@ myTexture.destroy()
 
 *  [`gl.deleteTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteTexture.xml)
 
-
-#### Profiling
+#### Texture profiling
 
 The following stats are tracked for each texture in the `.stats` property:
 
@@ -1718,9 +1720,11 @@ The following stats are tracked for each texture in the `.stats` property:
 | `size` | The size of the texture in bytes |
 
 ---------------------------------------
+
 ### Cube maps
 
-#### Constructor
+#### Cube map constructor
+
 Cube maps follow similar syntax to textures.  They are created using `regl.cube()`
 
 ```javascript
@@ -1752,7 +1756,8 @@ const anotherCubeMap = regl.cube({
 })
 ```
 
-#### Update
+#### Cube map update
+
 Cube maps can be reinitialized like textures or buffers:
 
 ```javascript
@@ -1765,7 +1770,8 @@ cube(4)
 cube.resize(16)
 ```
 
-##### In-place update
+##### Cube map subimage
+
 Sub-rectangles of faces of cube maps can be updated again using `.subimage`.
 
 ```javascript
@@ -1789,7 +1795,17 @@ cube.subimage(face, data[, x, y, miplevel])
 * [`gl.copyTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCopyTexSubImage2D.xml)
 * [`gl.compressedTexSubImage2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glCompressedTexSubImage2D.xml)
 
-#### Profiling
+#### Cube map resize
+
+Cube maps can be resized in place using the `.resize()` method.  This takes one argument which is the size of the cube map.
+
+```javascript
+var cubemap = regl.cube({ ... })
+
+cubemap.resize(16)
+```
+
+#### Cube map profiling
 
 The following stats are tracked for each cube map in the `.stats` property:
 
@@ -1797,7 +1813,7 @@ The following stats are tracked for each cube map in the `.stats` property:
 |-----------|---------|
 | `size` | The size of the cube map in bytes |
 
-#### Destroy
+#### Cube map destructor
 
 ```javascript
 cubeMap.destroy()
@@ -1808,9 +1824,11 @@ cubeMap.destroy()
 *  [`gl.deleteTexture`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteTexture.xml)
 
 ---------------------------------------
-### Render buffers
 
-#### Constructor
+### Renderbuffers
+
+#### Renderbuffer constructor
+
 ```javascript
 // Allocate a new renderbuffer with the prescribed format
 var rb = regl.renderbuffer({
@@ -1851,7 +1869,8 @@ var rgba_16x24 = regl.renderbuffer(16, 24)
 * [`gl.renderbufferStorage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glRenderbufferStorage.xml)
 * [`gl.bindRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindRenderbuffer.xml)
 
-#### Update
+#### Renderbuffer update
+
 Like all other resources, renderbuffers can be updated in place:
 
 ```javascript
@@ -1863,7 +1882,8 @@ renderbuffer({
 })
 ```
 
-##### Resizing
+##### Renderbuffer resize
+
 A renderbuffer can also be resized in place by calling `.resize()`:
 
 ```javascript
@@ -1875,7 +1895,7 @@ var renderbuffer = regl.renderbuffer({
 renderbuffer.resize(32, 32)
 ```
 
-#### Destroy
+#### Renderbuffers destructor
 
 ```javascript
 rb.destroy()
@@ -1885,8 +1905,7 @@ rb.destroy()
 
 * [`gl.deleteRenderbuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteRenderbuffer.xml)
 
-
-#### Profiling
+#### Renderbuffer profiling
 
 The following stats are tracked for each renderbuffer in the `.stats` property:
 
@@ -1895,10 +1914,10 @@ The following stats are tracked for each renderbuffer in the `.stats` property:
 | `size` | The size of the renderbuffer in bytes |
 
 ---------------------------------------
+
 ### Framebuffers
 
-#### Constructor
-Example,
+#### Framebuffer constructor
 
 ```javascript
 // Creating a simple 2x2 framebuffer:
@@ -1931,7 +1950,7 @@ var texFBO = regl.framebuffer({
 | `colorCount` | Sets the number of color buffers. Values > 1 require [WEBGL_draw_buffers](https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/) | `1` |
 | `depthTexture` | Toggles whether depth/stencil attachments should be in texture. Requires [WEBGL_depth_texture](https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/) | `false` |
 
-| Color format | Description | Attachment | Notes
+| Color format | Description | Attachment | Notes |
 |--------------|-------------|------------|-----|
 | `'rgba'` | `gl.RGBA` | Texture |              |
 | `'rgba4'` | `gl.RGBA4` | Renderbuffer |    |
@@ -1961,8 +1980,8 @@ var texFBO = regl.framebuffer({
 * [`gl.framebufferTexture2D`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glFramebufferTexture2D.xml)
 * [`gl.bindFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindFramebuffer.xml)
 
+#### Framebuffer update
 
-#### Update
 Like all other objects, a framebuffer can be updated in place:
 
 ```javascript
@@ -1974,7 +1993,8 @@ framebuffer({
 })
 ```
 
-##### Resizing
+##### Framebuffer resize
+
 Framebuffers can be resized using the `.resize()` method.  This method will also modify all of the framebuffer's attachments.
 
 ```javascript
@@ -1986,7 +2006,8 @@ framebuffer.resize(3, 3)
 framebuffer.resize(3)
 ```
 
-#### Destroy
+#### Framebuffer destructor
+
 Calling `.destroy()` on a framebuffer removes it and recursively destroys any non-shared attachments.
 
 ```javascript
@@ -1998,9 +2019,10 @@ fbo.destroy()
 * [`gl.deleteFramebuffer`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glDeleteFramebuffer.xml)
 
 ---------------------------------------
+
 ### Cubic frame buffers
 
-#### Constructor
+#### Cube framebuffer constructor
 
 ```javascript
 var cubeFbo = regl.framebufferCube(512)
@@ -2039,29 +2061,37 @@ var cubeAlt = regl.framebufferCube({
 * The specified depth/stencil/depth-stencil attachment will be reused
 for all 6 cube faces.
 
-#### Update
+#### Cube framebuffer update
 
 ```javascript
 // reinitialize
 fboCube({
   radius: 10
 })
-
-fboCube.resize(128)
 ```
 
-#### Destroy
+##### Cube framebuffer resize
+
+```javascript
+fboCube.resize(16)
+```
+
+#### Cube framebuffer destructor
 
 ```javascript
 fboCube.destroy()
 ```
 
 ---------------------------------------
-## Other features
+
+## Other tasks
+
 Other than draw commands and resources, there are a few miscellaneous parts of the WebGL API which REGL wraps for completeness.
 
 ---------------------------------------
+
 ### Clear the draw buffer
+
 `regl.clear` combines `gl.clearColor, gl.clearDepth, gl.clearStencil` and `gl.clear` into a single procedure, which has the following usage:
 
 ```javascript
@@ -2088,6 +2118,7 @@ If an option is not present, then the corresponding buffer is not cleared
 * [`gl.clear`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glClear.xml)
 
 ---------------------------------------
+
 ### Reading pixels
 
 ```javascript
@@ -2145,7 +2176,9 @@ regl({framebuffer: fbo})(() => {
 * [`gl.readPixels`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glReadPixels.xml)
 
 ---------------------------------------
+
 ### Per-frame callbacks
+
 `regl` also provides a common wrapper over `requestAnimationFrame` and `cancelAnimationFrame` that integrates gracefully with context loss events.  `regl.frame()` also calls `gl.flush` and drains several internal buffers, so you should try to do all your rendering to the drawing buffer within the frame callback.
 
 ```javascript
@@ -2164,7 +2197,9 @@ tick.cancel()
 It is possible to manage framecallbacks manually, however before any loop it is essential to call `regl.poll()` which updates all timers and viewports.
 
 ---------------------------------------
+
 ### Extensions
+
 In `regl`, extensions must be declared before they can be used.  An extension may be specified as a 'hard' requirement, meaning that if it is not present then context creation fails or as a 'soft' requirement.  This can be done by passing a list of extensions to the `extensions` and `optionalExtensions` fields in the regl constructor respectively.
 
 ```javascript
@@ -2197,7 +2232,9 @@ For more information on WebGL extensions, see the [WebGL extension registry](htt
 * `gl.getSupportedExtensions`
 
 ---------------------------------------
+
 ### Device capabilities and limits
+
 regl exposes info about the WebGL context limits and capabilities via the `regl.limits` object.  The following properties are supported,
 
 | Property | Description |
@@ -2233,7 +2270,9 @@ regl exposes info about the WebGL context limits and capabilities via the `regl.
 * [`gl.getParameter`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetParameter.xml)
 
 ---------------------------------------
+
 ### Performance metrics
+
 `regl` tracks several metrics for performance monitoring.  These can be read using the `regl.stats` object:
 
 | Metric | Meaning |
@@ -2253,7 +2292,9 @@ regl exposes info about the WebGL context limits and capabilities via the `regl.
 | `maxTextureUnits()` | The maximum number of texture units used |
 
 ---------------------------------------
+
 ### Clean up
+
 When a `regl` context is no longer needed, it can be destroyed releasing all associated resources with the following command:
 
 ```javascript
@@ -2261,13 +2302,17 @@ regl.destroy()
 ```
 
 ---------------------------------------
+
 ### Context loss
+
 `regl` makes a best faith effort to handle context loss by default.  This means that buffers and textures are reinitialized on a context restore with their contents.
 
 **TODO**
 
 ---------------------------------------
+
 ### Unsafe escape hatch
+
 **WARNING**: `regl` is designed in such a way that you should never have to directly access the underlying WebGL context. However, if you really absolutely need to do this for some reason (for example to interface with an external library), you can still get a reference to the WebGL context.  Note though that if you do this you will need to restore the `regl` state in order to prevent rendering errors.  This can be done with the following unsafe methods:
 
 ```javascript
@@ -2285,7 +2330,12 @@ regl._refresh()
 Note that you must call `regl._refresh()` if you have changed the WebGL state.
 
 ---------------------------------------
+
 ## Tips
+
+The following are some random tips for writing WebGL programs.  Some are regl specific and some are more generic.
+
+### Reuse commands
 
 ### Reuse resources (buffers, elements, textures, etc.)
 
@@ -2298,6 +2348,12 @@ Note that you must call `regl._refresh()` if you have changed the WebGL state.
 * Debug mode inserts many checks
 * Compiling in release mode removes these assertions, improves performance and reduces bundle size
 
-### Profiling
+### Profiling tips
 
 ### Context loss mitigation
+
+### Cameras
+
+### Use batch mode
+
+### Use glslify

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,32 +13,33 @@
 * Add a mechanism for users to specify minimum resource requirements (texture size, varying units, etc.)
 
 * Benchmark suite
-    + Dashboard for test cases and benchmarks
-    + Create some more typical drawing examples
+
+  * Dashboard for test cases and benchmarks
+  * Create some more typical drawing examples
 
 * A pretty printer for the generated code
 
 * Documentation
-    + All interface methods must be documented
-    + Examples for all major features
-    + Set up/quick start guides
-    + Live coding videos on youtube
-    + Talks?  (what conferences can we present these results at?)
-    + Core library modules need better comments
-    + Work flow for development and testing needs documentation
+
+  * All interface methods must be documented
+  * Examples for all major features
+  * Set up/quick start guides
+  * Live coding videos on youtube
+  * Talks?  (what conferences can we present these results at?)
+  * Core library modules need better comments
+  * Work flow for development and testing needs documentation
 
 * Helper modules
-    + A camera helper module to make getting started with 3D code easier
-    + Debugging tools for inspecting the state of framebuffers, textures, buffers
+
+  * A camera helper module to make getting started with 3D code easier
+  * Debugging tools for inspecting the state of framebuffers, textures, buffers
 
 * Recipe book/example set
-    + Globe
-    + Compound scene
-    + Stencil shadows
-    + Point-light shadows(through cubic framebuffers)
-    + Turing patterns
-    + Asset loading (obj, ply, etc.)
-    + Water Reflection(though cubic-framebuffers)
+
+  * Globe
+  * Turing patterns
+  * Asset loading (obj, ply, etc.)
+  * Water Reflection(though cubic-framebuffers)
 
 ## 0.11.0
 
@@ -53,11 +54,16 @@
 ## 0.10.0
 
 * Add a mechanism for managing webgl extensions
-    + Should be able to report errors when extensions are missing
-    + Allow users to disable extensions for testing/mocking
+
+  * Should be able to report errors when extensions are missing
+  * Allow users to disable extensions for testing/mocking
+
 * Doc clean up
+
 * Add more test cases for `regl.read()` and improve validation
+
 * Implement a standard method for handling context creation errors
+
 * Fix several bugs related to `regl.frame` cancellation
 
 ## 0.9.0
@@ -95,37 +101,57 @@
 ## 0.6.0
 
 * Allow for dynamic properties in viewport, scissor box and attributes
+
 * Switch order of arguments to dynamic functions, from (props, context) to (context, props)
-    + functions without a props argument become batch static
+
+  * functions without a props argument become batch static
+
 * Implement non-batch constant context, framebuffer and viewport
+
 * Batched scope rendering
+
 * Switch order of props and context variables for dynamic function args
+
 * function invocation now takes batch id as separate parameter
+
 * Support directly constructing elements and attributes from arrays
+
 * Allow individual attribute properties to be dynamic (eg buffers, offsets, etc.)
+
 * Code generation rewrite
-    + State flag polling is now inlined
-    + draw and batch inlined for static shaders
-    + constants are inlined
-    + fewer arguments passed to generated code
-    + Stop using separate arrays for stacks to manage state, instead state is saved onto the call stack
+
+  * State flag polling is now inlined
+  * draw and batch inlined for static shaders
+  * constants are inlined
+  * fewer arguments passed to generated code
+  * Stop using separate arrays for stacks to manage state, instead state is saved onto the call stack
+
 * Error reporting
-    + All error messages should link to command/resource declaration
-    + Improve validation of vertex attributes
-    + Improve validation of dynamic properties
+
+  * All error messages should link to command/resource declaration
+  * Improve validation of vertex attributes
+  * Improve validation of dynamic properties
+
 * Code quality and contributing
-    + Combined lib/state.js and lib/compile.js into lib/core.js
-    + Delete most of lib/attribute.js
-    + Update development documentation
+
+  * Combined lib/state.js and lib/compile.js into lib/core.js
+  * Delete most of lib/attribute.js
+  * Update development documentation
+
 * Expose limits for shader precision
 
 ## 0.5.0
 
 * Context variables
+
 * Use `this` argument effectively
-    * Should pass this to dynamic attributes and scope
+
+  * Should pass this to dynamic attributes and scope
+
 * Make scopes and dynamic attributes take same argument
+
 * Combine batchId with stats argument
+
 * Pass `this` to draw commands so that they can be stored as members
 
 ## 0.4.0

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -45,11 +45,11 @@ In addition to the standard style guidelines, we also enforce two extra constrai
 
 The reason we do not use ES5 in the library or test code is that regl supports node 0.10, which does not implement ES6.  Because the examples are meant to be illustrative we do not enforce the same strict compatibility requirements.
 
-For markdown, we're using [`remark`](https://github.com/wooorm/remark) and [`remark-lint`](https://github.com/wooorm/remark-lint) with a few checks disabled.  More info can be found in the `.remarkrc` file.
+For markdown, we're using [`remark`](https://github.com/wooorm/remark) and [`remark-lint`](https://github.com/wooorm/remark-lint).
 
 ## Tests
 
-`regl` uses [tape](https://www.npmjs.com/package/tape) for unit testing.  As a result, you can run any specific unit test directly in node like you would any other script without using any special unit test harness.  For example, to just run the texture2D tests, you could execute the following command from the root directory:
+`regl` uses [tape](https://www.npmjs.com/package/tape) for unit testing.  As a result, you can run any specific unit test directly in node like you would any other script without using any special unit test harness.  For example, to just run the texture2D tests, you could run the following command from the root directory:
 
 ```sh
 node test/texture2d.js

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,29 +1,33 @@
 # A developer's guide to regl
+
 This document is to help make it easier to contribute to `regl`.  It describes how some common workflows associated and how to get started with helping out.
 
 ## Basic set up
+
 To set up the development environment for regl, you first need to install [nodejs](https://nodejs.org/en/).  Any version >0.10 is supported.  Once this is done, you can install regl's development dependencies using the following npm command:
 
-```
+```sh
 npm install
 ```
 
 ## Examples
+
 `regl` has tons of examples.  To run them locally, you can use [budo](https://github.com/mattdesl/budo), which is a minimal HTTP server integrated with browserify.  To install budo, run the following command:
 
-```
+```sh
 npm install -g budo
 ```
 
 Then go into the example folder and run any example with the following command:
 
-```
+```sh
 budo basic.js --open
 ```
 
 Where you can replace `basic.js` with the name of whatever example you want to run.
 
 ### Adding an example
+
 To add an example, just create a javascript file in the `example` folder.  Each example should have a header comment at the top of the page that describes how it works.  This comment may contain HTML tags.
 
 If your example needs any static data, please put them in the `example/assets` directory.
@@ -31,6 +35,7 @@ If your example needs any static data, please put them in the `example/assets` d
 To add an image for your example, take a screen shot, name it `myexample.png` and place it in the `example/img` folder.
 
 ## Style guidelines
+
 `regl` adheres to the [standard](https://github.com/feross/standard) style.  The reason for this is to prevent "bikeshed" type discussions about code style and configuration that distract from actual issues.
 
 In addition to the standard style guidelines, we also enforce two extra constraints for technical reasons:
@@ -40,16 +45,19 @@ In addition to the standard style guidelines, we also enforce two extra constrai
 
 The reason we do not use ES5 in the library or test code is that regl supports node 0.10, which does not implement ES6.  Because the examples are meant to be illustrative we do not enforce the same strict compatibility requirements.
 
+For markdown, we're using [`remark`](https://github.com/wooorm/remark) and [`remark-lint`](https://github.com/wooorm/remark-lint) with a few checks disabled.  More info can be found in the `.remarkrc` file.
+
 ## Tests
+
 `regl` uses [tape](https://www.npmjs.com/package/tape) for unit testing.  As a result, you can run any specific unit test directly in node like you would any other script without using any special unit test harness.  For example, to just run the texture2D tests, you could execute the following command from the root directory:
 
-```
+```sh
 node test/texture2d.js
 ```
 
 To run all of the test cases in a batch, use the `npm` test script, which is the following command:
 
-```
+```sh
 npm test
 ```
 
@@ -57,45 +65,47 @@ npm test
 
 Some test cases make use of browser specific extensions and may need to run in a browser environment.  To run the test suite in a browser, use the following command:
 
-```
+```sh
 npm run test-browser
 ```
 
 regl also uses istanbul to measure code coverage for the test suite.  To generate a coverage report, use the following command:
 
-```
+```sh
 npm run cover
 ```
 
 Then you can view the results in `coverage/lcov-report/index.html`
 
 ### Adding a test case
+
 To add a test case, create a new file in the `test/` folder and then add a reference to it in `test/util/index.js`.  Take a look at the examples in the test folder for help.
 
 ## Benchmarks
+
 To run the benchmarks, use this command:
 
-```
+```sh
 npm run bench-node
 ```
 
 This will run the benchmarks in `node.js`, and output the results to `stdout` in
 json-format. If you want to see prettified benchmarks results, run
 
-```
+```sh
 npm run bench-node -- --pretty
 ```
 
 If you want to run the benchmarks in the browser, just run
 
-```
+```sh
 npm run bench-browser
 ```
 
 If you want to run the benchmarks on a bunch of commits in the history
 of the repo, do
 
-```
+```sh
 npm run bench-history 10
 ```
 
@@ -113,7 +123,7 @@ set up, so the benchmarking results produced by these commits should not be used
 Then you can create pretty graphs from the benchmark data outputted
 from `bench-history`. Just do
 
-```
+```sh
 npm run bench-graph bench/bench-result-2f95fbcf3e60dff98c4b.json
 ```
 
@@ -123,30 +133,35 @@ graphs made with `d3` from the data, and automatically open the HTML-file
 in your default browser.
 
 ### Adding a benchmark
+
 The easiest way to add a new benchmark is to copy an existing benchmark (see for example `bench/clear.js`), modify it, and add an entry to `bench/list.js`
 
 ### Size measurements
+
 You can also get a report of the current bundle size of regl using [disc](https://github.com/hughsk/disc).  [An up to date set of stats can be found in `www/size.html`.](https://mikolalysenko.github.io/regl/www/size.html)
 
 To regenerate these results, run the command
 
-```
+```sh
 npm run build-size
 ```
 
 ## Comparisons
+
 The [comparisons pages](https://mikolalysenko.github.io/regl/www/compare.html) is autogenerated from the contents of the `compare/` directory.  Each sub directory in the compare directory contains a task, and each task directory contains several implementations of this task.
 
 An implementation may be either a raw JavaScript file (which is compiled with browserify) or an HTML web page.  Each task must contain an image of the expected results (called `expected.png`) and a description called `description.txt`.
 
 ## Rebuilding the web assets
+
 To rebuild all redistributable assets and the static website, use the command:
 
-```
+```sh
 npm run build
 ```
 
 ## Find something to do
+
 Check out the [change log](CHANGES.md) for planned features and tasks.
 
 There is also a list of [open issues on GitHub that need work](https://github.com/mikolalysenko/regl/issues).  Anything with the "help wanted" tag may be good for a beginner starting out.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # regl
+
  [![Join the chat at https://gitter.im/ark-lang/ark](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mikolalysenko/regl) [![Circle CI](https://circleci.com/gh/mikolalysenko/regl.svg?style=shield)](https://circleci.com/gh/mikolalysenko/regl) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
  [![npm version](https://badge.fury.io/js/regl.svg)](https://badge.fury.io/js/regl) ![file size](https://badge-size.herokuapp.com/mikolalysenko/regl/gh-pages/dist/regl.min.js.svg?compression=gzip)
 
-`regl` is a fast functional framework for WebGL.
+`regl` is a fast functional framework for WebGL. [For detailed info, check out the API docs.](API.md)
 
 ## Example
 
@@ -11,7 +12,7 @@ In `regl`, there are two fundamental abstractions, **resources** and **commands*
 * A **resource** is a handle to a GPU resident object, like a texture, FBO or buffer.
 * A **command** is a complete representation of the WebGL state required to perform some draw call.
 
-To define a command you specify a mixture of static and dynamic data for the object. Once this is done, `regl` takes this description and then compiles it into optimized JavaScript code.  For example, here is a simple `regl` program to draw a colored triangle:
+To define a command you specify a mixture of static and dynamic data for the object. Once this is done, `regl` takes this description and then compiles it into optimized JavaScript code.  For example, here is a simple `regl` program to draw a triangle:
 
 ```JavaScript
 // Calling the regl module with no arguments creates a full screen canvas and
@@ -79,18 +80,20 @@ regl.frame(({time}) => {
 
 See this example [live](http://regl.party/examples/?basic)
 
-#### More examples
+### More examples
 
 Check out the [gallery](https://mikolalysenko.github.io/regl/www/gallery.html). The source code of all the gallery examples can be found [here](https://github.com/mikolalysenko/regl/tree/gh-pages/example).
 
 ## Setup
 
-regl has no dependencies, so setting it up is pretty easy
+`regl` has no dependencies, so setting it up is pretty easy.  There are 3 basic ways to do this:
 
-#### Live editing
+### Live editing
+
 To try out regl right away, you can use the live editor in the [gallery](http://regl.party/examples).
 
-#### npm
+### npm
+
 The easiest way to use `regl` in a project is via [npm](http://npmjs.com).  Once you have node set up, you can install and use `regl` in your project using the following command:
 
 ```sh
@@ -99,147 +102,61 @@ npm i -S regl
 
 For more info on how to use npm, [check out the official docs](https://docs.npmjs.com/).
 
-#### Standalone script tag
-You can also use `regl` as a standalone script if you are really stubborn.  The most recent versions can be found in the `dist/` folder.  Alternatively, you can directly import regl using npm cdn.
+### Standalone script tag
 
-* Unminified:
+You can also use `regl` as a standalone script if you are really stubborn.  The most recent versions can be found in the `dist/` folder.  Alternatively, you can directly import `regl` using [npm cdn](https://npmcdn.com).
+
+#### Unminified
 
 ```html
 <script src="https://npmcdn.com/regl/dist/regl.js"></script>
 ```
 
-* Minified:
+#### Minified
 
 ```html
 <script src="https://npmcdn.com/regl/dist/regl.min.js"></script>
 ```
 
-## Why use `regl`?
-`regl` is basically all of WebGL without all of the shared state.  You can do anything you could in regular WebGL with little overhead and way less debugging. `regl` emphasizes the following values:
+## Why `regl`
+
+`regl` just removes shared state from WebGL.  You can do anything you could in regular WebGL with little overhead and way less debugging. `regl` emphasizes the following values:
 
 * **Simplicity** The interface is concise and emphasizes separation of concerns.  Removing shared state helps localize the effects and interactions of code, making it easier to reason about.
 * **Correctness** `regl` has more than 30,000 unit tests and above 95% code coverage. In development mode, `regl` performs strong validation and sanity checks on all input data to help you catch errors faster.
 * **Performance**  `regl` uses dynamic code generation and partial evaluation to remove almost all overhead. Draw commands execute roughly as fast as hand optimized WebGL.
-* **Minimalism** `regl` just wraps WebGL.  It is not a game engine and doesn't have opinions about scene graphs or vector math libraries.
+* **Minimalism** `regl` just wraps WebGL.  It is not a game engine and doesn't have opinions about scene graphs or vector math libraries.   Any feature in WebGL is accessible, including advanced extensions like [multiple render targets](https://github.com/mikolalysenko/regl/blob/gh-pages/example/deferred_shading.js) or [instancing](https://github.com/mikolalysenko/regl/blob/gh-pages/example/instance-triangle.js).
 * **Stability** `regl` takes interface compatibility and semantic versioning seriously, making it well suited for long lived applications that must be supported for months or years down the road.  It also has no dependencies limiting exposure to risky or unplanned updates.
-* **Power** Any feature in WebGL is accessible, including advanced extensions like [multiple render targets](https://github.com/mikolalysenko/regl/blob/gh-pages/example/deferred_shading.js) or [instancing](https://github.com/mikolalysenko/regl/blob/gh-pages/example/instance-triangle.js).
 
-### Comparisons
-While `regl` is lower level than many 3D engines, code written in it tends to be highly compact and flexible.  A comparison of `regl` to various other WebGL [libraries across several tasks can be found here](https://mikolalysenko.github.io/regl/www/).
+### [Comparisons](https://mikolalysenko.github.io/regl/www/compare.html)
 
-### Benchmarks
-In order to prevent performance regressions, `regl` is continuously benchmarked.  You can run benchmarks locally using `npm run bench` or [check them out online](https://mikolalysenko.github.io/regl/www/bench.html). The results for the last few days can be found here:
+While `regl` is lower level than many 3D engines, code written in it tends to be highly compact and flexible.  A comparison of `regl` to various other WebGL [libraries across several tasks can be found here](https://mikolalysenko.github.io/regl/www/compare.html).
 
-* [Benchmarking Results](https://mikolalysenko.github.io/regl/www/bench-results/bench-result-8ea4a7e806beed0b9732)
+### [Benchmarks](https://mikolalysenko.github.io/regl/www/bench-results/bench-result-8ea4a7e806beed0b9732)
 
-The benchmarking results were created by using our custom scripts `bench-history` and
-`bench-graph`. You can read more about them in [DEVELOPING.md](DEVELOPING.md).
+In order to prevent performance regressions, `regl` is continuously benchmarked.  You can run benchmarks locally using `npm run bench` or [check them out online](https://mikolalysenko.github.io/regl/www/bench.html). The [results for the last few days can be found here.](https://mikolalysenko.github.io/regl/www/bench-results/bench-result-8ea4a7e806beed0b9732)
+
+These measurements were taken using our custom scripts `bench-history` and
+`bench-graph`. You can read more about them in [the development guide](DEVELOPING.md).
 
 ## [API](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md)
 
-* [Initialization](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#initialization)
-    - [As a fullscreen canvas](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#as-a-fullscreen-canvas)
-    - [From a container div](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#from-a-container-div)
-    - [From a canvas](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#from-a-canvas)
-    - [From a WebGL context](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#from-a-webgl-context)
-  + [All initialization options](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#all-initialization-options)
-* [Commands](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#commands)
-  + [Executing commands](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#executing-commands)
-    - [One-shot rendering](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#one-shot-rendering)
-    - [Batch rendering](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#batch-rendering)
-    - [Scoped commands](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#scoped-commands)
-  + [Inputs](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#inputs)
-    - [Example](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#example)
-    - [Context](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#context)
-    - [Props](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#props)
-    - [`this`](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#-this-)
-  + [Parameters](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#parameters)
-    - [Shaders](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#shaders)
-    - [Uniforms](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#uniforms)
-    - [Attributes](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#attributes)
-    - [Drawing](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#drawing)
-    - [Render target](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#render-target)
-    - [Profiling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#profiling)
-    - [Depth buffer](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#depth-buffer)
-    - [Blending](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#blending)
-    - [Stencil](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#stencil)
-    - [Polygon offset](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#polygon-offset)
-    - [Culling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#culling)
-    - [Front face](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#front-face)
-    - [Dithering](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#dithering)
-    - [Line width](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#line-width)
-    - [Color mask](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#color-mask)
-    - [Sample coverage](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#sample-coverage)
-    - [Scissor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#scissor)
-    - [Viewport](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#viewport)
-* [Resources](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#resources)
-  + [Buffers](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#buffers)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update)
-      * [In place update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#in-place-update)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy)
-    - [Profiling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#profiling-1)
-  + [Elements](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#elements)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor-1)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update-1)
-      * [In-place update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#in-place-update)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy-1)
-  + [Textures](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#textures)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor-2)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update-2)
-      * [Partial update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#partial-update)
-      * [Resize](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#resize)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy-2)
-    - [Profiling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#profiling-2)
-  + [Cube maps](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#cube-maps)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor-3)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update-3)
-      * [In-place update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#in-place-update-1)
-    - [Profiling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#profiling-3)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy-3)
-  + [Render buffers](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#render-buffers)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor-4)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update-4)
-      * [Resizing](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#resizing)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy-4)
-    - [Profiling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#profiling-4)
-  + [Framebuffers](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#framebuffers)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor-5)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update-5)
-      * [Resizing](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#resizing-1)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy-5)
-  + [Cubic frame buffers](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#cubic-frame-buffers)
-    - [Constructor](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#constructor-6)
-    - [Update](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#update-6)
-    - [Destroy](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#destroy-6)
-* [Other features](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#other-features)
-  + [Clear the draw buffer](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#clear-the-draw-buffer)
-  + [Reading pixels](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#reading-pixels)
-  + [Per-frame callbacks](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#per-frame-callbacks)
-  + [Extensions](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#extensions)
-  + [Device capabilities and limits](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#device-capabilities-and-limits)
-  + [Performance metrics](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#performance-metrics)
-  + [Clean up](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#clean-up)
-  + [Context loss](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#context-loss)
-  + [Unsafe escape hatch](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#unsafe-escape-hatch)
-* [Tips](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#tips)
-  + [Reuse resources (buffers, elements, textures, etc.)](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#reuse-resources--buffers--elements--textures--etc-)
-  + [Preallocate memory](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#preallocate-memory)
-  + [Debug vs release](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#debug-vs-release)
-  + [Profiling](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#profiling-5)
-  + [Context loss mitigation](https://github.com/mikolalysenko/regl/blob/gh-pages/API.md#context-loss-mitigation)
+`regl` has extensive API documentation.  A copy
 
 ## Development
+
 The latest changes in `regl` can be found in the [CHANGELOG](CHANGES.md).
 
 [For info on how to build and test headless, see the contributing guide here](DEVELOPING.md)
 
 ### License
+
 All code (c) 2016 MIT License
 
 Development supported by the [Freeman Lab](https://www.janelia.org/lab/freeman-lab) and the Howard Hughes Medical Institute ([@freeman-lab](https://github.com/freeman-lab) on GitHub)
 
 #### Asset licenses
+
 Many examples use creative commons or public domain artwork for illustrative purposes.  These assets are not included in any of the redistributable packages of regl.
 
 * Test video (doggie-chromakey.ogv) by [L0ckergn0me](https://archive.org/details/L0ckergn0me-PixieGreenScreen446), used under creative commons license

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can also use `regl` as a standalone script if you are really stubborn.  The 
 
 * **Simplicity** The interface is concise and emphasizes separation of concerns.  Removing shared state helps localize the effects and interactions of code, making it easier to reason about.
 * **Correctness** `regl` has more than 30,000 unit tests and above 95% code coverage. In development mode, `regl` performs strong validation and sanity checks on all input data to help you catch errors faster.
-* **Performance**  `regl` uses dynamic code generation and partial evaluation to remove almost all overhead. Draw commands execute roughly as fast as hand optimized WebGL.
+* **Performance**  `regl` uses dynamic code generation and partial evaluation to remove almost all overhead.
 * **Minimalism** `regl` just wraps WebGL.  It is not a game engine and doesn't have opinions about scene graphs or vector math libraries.   Any feature in WebGL is accessible, including advanced extensions like [multiple render targets](https://github.com/mikolalysenko/regl/blob/gh-pages/example/deferred_shading.js) or [instancing](https://github.com/mikolalysenko/regl/blob/gh-pages/example/instance-triangle.js).
 * **Stability** `regl` takes interface compatibility and semantic versioning seriously, making it well suited for long lived applications that must be supported for months or years down the road.  It also has no dependencies limiting exposure to risky or unplanned updates.
 

--- a/compare/cube/threejs_cube.html
+++ b/compare/cube/threejs_cube.html
@@ -21,7 +21,7 @@
     function drawShape() {
       var geo = new THREE.CubeGeometry(1.0, 1.0, 1.0);
 
-      var texture = THREE.ImageUtils.loadTexture('../example/assets/lena.png');
+      var texture = THREE.ImageUtils.loadTexture('assets/lena.png');
       var mats = [];
       for (var i = 0; i < 6; i++) {
         mats.push(new THREE.MeshBasicMaterial({map: texture}));

--- a/compare/cube/webgl_cube.html
+++ b/compare/cube/webgl_cube.html
@@ -178,7 +178,7 @@ function initTextures () {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
   }
-  cubeImage.src = '../example/assets/lena.png'
+  cubeImage.src = 'assets/lena.png'
 }
 
 function drawScene () {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "remark-validate-links": "^4.1.0"
   },
   "scripts": {
-    "test": "standard | snazzy && npm run lint-docs && npm run language-check && tape test/util/index.js | faucet",
+    "test": "standard | snazzy && npm run language-check && tape test/util/index.js | faucet",
     "test-browser": "budo test/util/browser.js --open",
     "cover": "istanbul cover test/util/index.js",
     "bench-browser": "budo bench/bench.js --open",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "build-bench": "browserify bench/bench.js | indexhtmlify > www/bench.html",
     "build-gallery": "node bin/build-gallery.js",
     "build-compare": "node bin/build-compare.js",
-    "build-docs": "remark API.md ",
+    "build-docs": "remark API.md -o API.md",
     "lint-docs": "remark --frail --quiet README.md API.md DEVELOPING.md CHANGES.md"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -54,21 +54,22 @@
     "vectorize-text": "^3.0.2"
   },
   "scripts": {
-    "mytest": "standard | snazzy && tape test/stats.js",
-    "test": "standard | snazzy && tape test/util/index.js | faucet",
+    "test": "standard | snazzy && npm run lint-docs && tape test/util/index.js | faucet",
     "test-browser": "budo test/util/browser.js --open",
     "cover": "istanbul cover test/util/index.js",
     "bench-browser": "budo bench/bench.js --open",
     "bench-node": "node bench/bench.js",
     "bench-graph": "node bench/bench-graph.js",
     "bench-history": "node bench/bench-history",
-    "build": "npm run build-script && npm run build-min && npm run build-bench && npm run build-gallery && npm run size && npm run build-compare",
-    "size": "browserify --full-paths --transform ./bin/remove-check.js regl.js | discify > www/size.html",
+    "build": "npm run build-script && npm run build-min && npm run build-bench && npm run build-gallery && npm run build-size && npm run build-compare && npm run build-docs",
+    "build-size": "browserify --full-paths --transform ./bin/remove-check.js regl.js | discify > www/size.html",
     "build-script": "browserify regl.js --standalone reglInit > dist/regl.js",
     "build-min": "node bin/build-min.js",
     "build-bench": "browserify bench/bench.js | indexhtmlify > www/bench.html",
     "build-gallery": "node bin/build-gallery.js",
-    "build-compare": "node bin/build-compare.js"
+    "build-compare": "node bin/build-compare.js",
+    "build-docs": "remark API.md > API.md",
+    "lint-docs": "remark README.md && remark API.md && remark CHANGES.md && remark DEVELOPING.md"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "remark-validate-links": "^4.1.0"
   },
   "scripts": {
-    "test": "standard | snazzy && npm run language-check && tape test/util/index.js | faucet",
+    "test": "standard | snazzy && tape test/util/index.js | faucet",
     "test-browser": "budo test/util/browser.js --open",
     "cover": "istanbul cover test/util/index.js",
     "bench-browser": "budo bench/bench.js --open",

--- a/package.json
+++ b/package.json
@@ -51,10 +51,15 @@
     "teapot": "^1.0.0",
     "three": "^0.79.0",
     "through2": "^2.0.1",
-    "vectorize-text": "^3.0.2"
+    "vectorize-text": "^3.0.2",
+    "remark": "^5.0.1",
+    "remark-cli": "^1.0.0",
+    "remark-lint": "^4.1.0",
+    "remark-toc": "^3.1.0",
+    "remark-validate-links": "^4.1.0"
   },
   "scripts": {
-    "test": "standard | snazzy && npm run lint-docs && tape test/util/index.js | faucet",
+    "test": "standard | snazzy && npm run lint-docs && npm run language-check && tape test/util/index.js | faucet",
     "test-browser": "budo test/util/browser.js --open",
     "cover": "istanbul cover test/util/index.js",
     "bench-browser": "budo bench/bench.js --open",
@@ -69,7 +74,7 @@
     "build-gallery": "node bin/build-gallery.js",
     "build-compare": "node bin/build-compare.js",
     "build-docs": "remark API.md ",
-    "lint-docs": "remark --frail README.md API.md DEVELOPING.md CHANGES.md"
+    "lint-docs": "remark --frail --quiet README.md API.md DEVELOPING.md CHANGES.md"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,15 +61,15 @@
     "bench-node": "node bench/bench.js",
     "bench-graph": "node bench/bench-graph.js",
     "bench-history": "node bench/bench-history",
-    "build": "npm run build-script && npm run build-min && npm run build-bench && npm run build-gallery && npm run build-size && npm run build-compare && npm run build-docs",
+    "build": "npm run build-script && npm run build-min && npm run build-bench && npm run build-gallery && npm run build-size && npm run build-compare",
     "build-size": "browserify --full-paths --transform ./bin/remove-check.js regl.js | discify > www/size.html",
     "build-script": "browserify regl.js --standalone reglInit > dist/regl.js",
     "build-min": "node bin/build-min.js",
     "build-bench": "browserify bench/bench.js | indexhtmlify > www/bench.html",
     "build-gallery": "node bin/build-gallery.js",
     "build-compare": "node bin/build-compare.js",
-    "build-docs": "remark API.md > API.md",
-    "lint-docs": "remark README.md && remark API.md && remark CHANGES.md && remark DEVELOPING.md"
+    "build-docs": "remark API.md ",
+    "lint-docs": "remark --frail README.md API.md DEVELOPING.md CHANGES.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Went down a rabbit hole and implemented a linter for all the docs. It currently doesn't run on CI due to an incompatibility with node 0.10, but you can still use it locally.

Also the table for the API docs are now auto generated.