### PR TITLE
API.md: Fix gl.sampleCoverage link

### DIFF
--- a/API.md
+++ b/API.md
@@ -1239,7 +1239,7 @@ var command = regl({
 
 **Relevant WebGL APIs**
 
--   [`gl.sampleCoverage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glColorMask.xml)
+-   [`gl.sampleCoverage`](https://www.khronos.org/opengles/sdk/docs/man/xhtml/glSampleCoverage.xml)
 
 * * *
 


### PR DESCRIPTION
Fix link to gl.sampleCoverage in API.md