### PR TITLE
Better error message for inconsistent array length for texture.

### DIFF
--- a/lib/texture.js
+++ b/lib/texture.js
@@ -232,7 +232,7 @@ function typedArrayCode (data) {
 
 function convertData (result, data) {
   var n = result.width * result.height * result.channels
-  check(data.length === n, 'inconsistent array length for texture')
+  check(data.length === n, 'inconsistent array length for texture. Expected: ' + n + '. Was: ' + data.length)
 
   switch (result.type) {
     case GL_UNSIGNED_BYTE:


### PR DESCRIPTION
Made the error message "inconsistent array length for texture" more helpful.