### PR TITLE
Add simple script to check missing npm dependencies

### DIFF
--- a/bin/check-dependecies.js
+++ b/bin/check-dependecies.js
@@ -1,0 +1,34 @@
+const depCheck = require('dependency-check')
+const deglob = require('deglob')
+const path = require('path')
+
+const ROOT = path.join(__dirname, '..')
+
+// reference: https://github.com/flet/deglob
+// Find all js files but exclude
+// - patterns defined in `.gitignore`
+// - ignore list defined in `package.json`
+const option = {
+  configKey: 'standard'
+}
+
+deglob('**/*.js', option, (err, files) => {
+  if (err) throw err
+
+  depCheck({
+    path: ROOT,
+    entries: files.map(path.relative.bind(null, ROOT)),
+    noDefaultEntries: true
+  }, (err, data) => {
+    if (err) throw err
+
+    // check missing dependencies
+    var result = depCheck.missing(data.package, data.used)
+
+    result.length && console.error(`
+      Dependencies not listed in package.json:
+        ${result.join('\n\t')}
+    `)
+    process.exit(result.length)
+  })
+})

--- a/bin/check-dependecies.js
+++ b/bin/check-dependecies.js
@@ -1,34 +1,33 @@
-const depCheck = require('dependency-check')
-const deglob = require('deglob')
-const path = require('path')
+var depCheck = require('dependency-check')
+var deglob = require('deglob')
+var path = require('path')
 
-const ROOT = path.join(__dirname, '..')
+var ROOT = path.join(__dirname, '..')
 
 // reference: https://github.com/flet/deglob
 // Find all js files but exclude
 // - patterns defined in `.gitignore`
 // - ignore list defined in `package.json`
-const option = {
+var option = {
   configKey: 'standard'
 }
 
-deglob('**/*.js', option, (err, files) => {
+deglob('**/*.js', option, function (err, files) {
   if (err) throw err
 
   depCheck({
     path: ROOT,
     entries: files.map(path.relative.bind(null, ROOT)),
     noDefaultEntries: true
-  }, (err, data) => {
+  }, function (err, data) {
     if (err) throw err
 
     // check missing dependencies
     var result = depCheck.missing(data.package, data.used)
 
-    result.length && console.error(`
-      Dependencies not listed in package.json:
-        ${result.join('\n\t')}
-    `)
+    if (result.length) {
+      console.error(['Dependencies not listed in package.json:'].concat(result).join('\n\t') + '\n')
+    }
     process.exit(result.length)
   })
 })

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "canvas-orbit-camera": "^1.0.2",
     "control-panel": "^1.2.0",
     "conway-hart": "^0.1.0",
+    "deglob": "^1.1.1",
+    "dependency-check": "^2.6.0",
     "disc": "^1.3.2",
     "falafel": "^1.2.0",
     "faucet": "0.0.1",
@@ -74,7 +76,7 @@
     "build-script": "browserify regl.js --standalone createREGL > dist/regl.js",
     "build-min": "node bin/build-min.js",
     "build-bench": "browserify bench/bench.js | indexhtmlify > www/bench.html",
-    "build-gallery": "node bin/build-gallery.js",
+    "build-gallery": "node bin/check-dependecies.js && node bin/build-gallery.js",
     "build-compare": "node bin/build-compare.js",
     "build-docs": "remark API.md -o API.md",
     "lint-docs": "remark --frail --quiet README.md API.md DEVELOPING.md CHANGES.md"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "vertices-bounding-box": "^1.0.0"
   },
   "scripts": {
-    "test": "standard | snazzy && tape test/util/index.js | faucet",
+    "test": "node bin/check-dependecies.js && standard | snazzy && tape test/util/index.js | faucet",
     "test-browser": "budo test/util/browser.js --open",
     "cover": "istanbul cover test/util/index.js",
     "bench-browser": "budo bench/bench.js --open",
@@ -76,7 +76,7 @@
     "build-script": "browserify regl.js --standalone createREGL > dist/regl.js",
     "build-min": "node bin/build-min.js",
     "build-bench": "browserify bench/bench.js | indexhtmlify > www/bench.html",
-    "build-gallery": "node bin/check-dependecies.js && node bin/build-gallery.js",
+    "build-gallery": "node bin/build-gallery.js",
     "build-compare": "node bin/build-compare.js",
     "build-docs": "remark API.md -o API.md",
     "lint-docs": "remark --frail --quiet README.md API.md DEVELOPING.md CHANGES.md"


### PR DESCRIPTION
Currently it check all `js` files except patterns in `.gitignore` and ignore list of `standard`
Refer to https://github.com/mikolalysenko/regl/pull/243
