### PR TITLE
Stencil buffer interface improvements

### DIFF
--- a/API.md
+++ b/API.md
@@ -971,12 +971,12 @@ var command = regl({
     opFront: {
       fail: 'keep',
       zfail: 'keep',
-      pass: 'keep'
+      zpass: 'keep'
     },
     opBack: {
       fail: 'keep',
       zfail: 'keep',
-      pass: 'keep'
+      zpass: 'keep'
     }
   },
 
@@ -989,8 +989,9 @@ var command = regl({
 | `enable`  | Toggles `gl.enable(gl.STENCIL_TEST)`       | `false`                                  |
 | `mask`    | Sets `gl.stencilMask`                      | `-1`                                     |
 | `func`    | Sets `gl.stencilFunc`                      | `{cmp:'always',ref:0,mask:-1}`           |
-| `opFront` | Sets `gl.stencilOpSeparate` for front face | `{fail:'keep',zfail:'keep',pass:'keep'}` |
-| `opBack`  | Sets `gl.stencilOpSeparate` for back face  | `{fail:'keep',zfail:'keep',pass:'keep'}` |
+| `opFront` | Sets `gl.stencilOpSeparate` for front face | `{fail:'keep',zfail:'keep',zpass:'keep'}` |
+| `opBack`  | Sets `gl.stencilOpSeparate` for back face  | `{fail:'keep',zfail:'keep',zpass:'keep'}` |
+| `op` | Sets `opFront` and `opBack` simultaneously | |
 
 **Notes**
 
@@ -1017,9 +1018,9 @@ var command = regl({
 
     -   `fail`, the stencil op which is applied when the stencil test fails
     -   `zfail`, the stencil op which is applied when the stencil test passes and the depth test fails
-    -   `pass`, the stencil op which is applied when both stencil and depth tests pass
+    -   `zpass`, the stencil op which is applied when both stencil and depth tests pass
 
--   Values for `opFront.fail`, `opFront.zfail`, etc. can come from the following table
+-   Values for `op.fail`, `op.zfail`, `op.zpass` can come from the following table
 
 | Stencil Op         | Description    |
 | ------------------ | -------------- |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
 
 ## Next
 
+* Support `stencil.op`
 * Rename stencil op `pass` to `zpass`
 * Attribute pointers can now use buffer literals
 * Implement basic context loss handling

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
 
 ## Next
 
+* Rename stencil op `pass` to `zpass`
 * Attribute pointers can now use buffer literals
 * Implement basic context loss handling
 * Add `regl.on` for hooking events

--- a/example/shadow-volume.js
+++ b/example/shadow-volume.js
@@ -150,12 +150,12 @@ require('resl')({
         opBack: {
           fail: 'keep',
           zfail: 'increment wrap',
-          pass: 'keep'
+          zpass: 'keep'
         },
         opFront: {
           fail: 'keep',
           zfail: 'decrement wrap',
-          pass: 'keep'
+          zpass: 'keep'
         }
       },
       // do no culling. This means that we can write to the stencil
@@ -190,12 +190,7 @@ require('resl')({
         },
         // do no writing to stencil buffer in this pass.
         // we already did that in the previous pass.
-        opBack: {
-          fail: 'keep',
-          zfail: 'keep',
-          pass: 'keep'
-        },
-        opFront: {
+        op: {
           fail: 'keep',
           zfail: 'keep',
           pass: 'keep'

--- a/example/stencil-transition.js
+++ b/example/stencil-transition.js
@@ -274,7 +274,7 @@ const createMask = regl({
     opFront: {
       fail: 'replace',
       zfail: 'replace',
-      pass: 'replace'
+      zpass: 'replace'
     }
   },
   // we want to write only to the stencil buffer,

--- a/lib/core.js
+++ b/lib/core.js
@@ -1392,15 +1392,15 @@ module.exports = function reglCore (
               check.commandType(value, 'object', param, env.commandStr)
               var fail = value.fail || 'keep'
               var zfail = value.zfail || 'keep'
-              var pass = value.pass || 'keep'
+              var zpass = value.zpass || 'keep'
               check.commandParameter(fail, stencilOps, prop + '.fail', env.commandStr)
               check.commandParameter(zfail, stencilOps, prop + '.zfail', env.commandStr)
-              check.commandParameter(pass, stencilOps, prop + '.pass', env.commandStr)
+              check.commandParameter(zpass, stencilOps, prop + '.zpass', env.commandStr)
               return [
                 prop === S_STENCIL_OPBACK ? GL_BACK : GL_FRONT,
                 stencilOps[fail],
                 stencilOps[zfail],
-                stencilOps[pass]
+                stencilOps[zpass]
               ]
             },
             function (env, scope, value) {
@@ -1430,7 +1430,7 @@ module.exports = function reglCore (
                 prop === S_STENCIL_OPBACK ? GL_BACK : GL_FRONT,
                 read('fail'),
                 read('zfail'),
-                read('pass')
+                read('zpass')
               ]
             })
 

--- a/regl.js
+++ b/regl.js
@@ -273,6 +273,11 @@ module.exports = function wrapREGL (args) {
       delete result.attributes
       delete result.context
 
+      if ('stencil' in result && result.stencil.op) {
+        result.stencil.opBack = result.stencil.opFront = result.stencil.op
+        delete result.stencil.op
+      }
+
       function merge (name) {
         if (name in result) {
           var child = result[name]

--- a/test/framebuffer-depth-stencil.js
+++ b/test/framebuffer-depth-stencil.js
@@ -55,10 +55,10 @@ tape('framebuffer - depth stencil attachment', function (t) {
         }
       },
       opFront: {
-        pass: 'increment'
+        zpass: 'increment'
       },
       opBack: {
-        pass: 'increment'
+        zpass: 'increment'
       }
     }
   })

--- a/test/stencil.js
+++ b/test/stencil.js
@@ -71,7 +71,9 @@ tape('stencil', function (t) {
     same(gl.STENCIL_WRITEMASK, flags.mask, 'mask')
 
     function sameOp (pname, name, face) {
-      same(pname, stencilOps[flags[face][name]], face + '.' + name)
+      same(pname,
+        stencilOps.op ? stencilOps.op[name] : stencilOps[flags[face][name]],
+        face + '.' + name)
     }
 
     sameOp(gl.STENCIL_FAIL, 'fail', 'opFront')
@@ -120,6 +122,20 @@ tape('stencil', function (t) {
         fail: 'zero',
         zfail: 'decrement',
         zpass: 'decrement wrap'
+      }
+    },
+    {
+      enable: true,
+      func: {
+        cmp: 'always',
+        ref: 0,
+        mask: 0xff
+      },
+      mask: 0xff,
+      op: {
+        fail: 'keep',
+        zfail: 'replace',
+        zpass: 'keep'
       }
     }
   ]
@@ -190,11 +206,17 @@ tape('stencil', function (t) {
   }, staticOptions))
 
   permutations.forEach(function (params, i) {
+    if (params.op) {
+      return
+    }
     dynamicDraw(params)
     testFlags('dynamic 1-shot - #' + i + ' - x', params)
   })
 
   permutations.forEach(function (params, i) {
+    if (params.op) {
+      return
+    }
     dynamicDraw([params])
     testFlags('batch - #' + i + ' - x', params)
   })
@@ -232,11 +254,17 @@ tape('stencil', function (t) {
   }, staticOptions))
 
   permutations.forEach(function (params, i) {
+    if (params.op) {
+      return
+    }
     nestedDynamicDraw(params)
     testFlags('nested dynamic 1-shot - #' + i + ' - ', params)
   })
 
   permutations.forEach(function (params, i) {
+    if (params.op) {
+      return
+    }
     nestedDynamicDraw([params])
     testFlags('nested batch - #' + i + ' - ', params)
   })

--- a/test/stencil.js
+++ b/test/stencil.js
@@ -76,11 +76,11 @@ tape('stencil', function (t) {
 
     sameOp(gl.STENCIL_FAIL, 'fail', 'opFront')
     sameOp(gl.STENCIL_PASS_DEPTH_FAIL, 'zfail', 'opFront')
-    sameOp(gl.STENCIL_PASS_DEPTH_PASS, 'pass', 'opFront')
+    sameOp(gl.STENCIL_PASS_DEPTH_PASS, 'zpass', 'opFront')
 
     sameOp(gl.STENCIL_BACK_FAIL, 'fail', 'opBack')
     sameOp(gl.STENCIL_BACK_PASS_DEPTH_FAIL, 'zfail', 'opBack')
-    sameOp(gl.STENCIL_BACK_PASS_DEPTH_PASS, 'pass', 'opBack')
+    sameOp(gl.STENCIL_BACK_PASS_DEPTH_PASS, 'zpass', 'opBack')
   }
 
   var permutations = [
@@ -95,12 +95,12 @@ tape('stencil', function (t) {
       opFront: {
         fail: 'keep',
         zfail: 'replace',
-        pass: 'keep'
+        zpass: 'keep'
       },
       opBack: {
         fail: 'keep',
         zfail: 'keep',
-        pass: 'keep'
+        zpass: 'keep'
       }
     },
     {
@@ -114,12 +114,12 @@ tape('stencil', function (t) {
       opFront: {
         fail: 'invert',
         zfail: 'increment',
-        pass: 'increment wrap'
+        zpass: 'increment wrap'
       },
       opBack: {
         fail: 'zero',
         zfail: 'decrement',
-        pass: 'decrement wrap'
+        zpass: 'decrement wrap'
       }
     }
   ]
@@ -137,12 +137,12 @@ tape('stencil', function (t) {
       opFront: {
         fail: 'keep',
         zfail: 'keep',
-        pass: 'keep'
+        zpass: 'keep'
       },
       opBack: {
         fail: 'keep',
         zfail: 'keep',
-        pass: 'keep'
+        zpass: 'keep'
       }
     }
     )
@@ -221,12 +221,12 @@ tape('stencil', function (t) {
       opFront: {
         fail: regl.prop('opFront.fail'),
         zfail: regl.prop('opFront.zfail'),
-        pass: regl.prop('opFront.pass')
+        zpass: regl.prop('opFront.zpass')
       },
       opBack: {
         fail: regl.prop('opBack.fail'),
         zfail: regl.prop('opBack.zfail'),
-        pass: regl.prop('opBack.pass')
+        zpass: regl.prop('opBack.zpass')
       }
     }
   }, staticOptions))


### PR DESCRIPTION
* Changes `pass` to `zpass`
* Can now specify `op` to simultaneously set `opFront` and `opBack`