### PR TITLE
lib/core.js: fix instancing extension injection

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2110,7 +2110,7 @@ module.exports = function reglCore (
   }
 
   function injectExtensions (env, scope) {
-    if (extInstancing && !env.instancing) {
+    if (extInstancing) {
       env.instancing = scope.def(
         env.shared.extensions, '.angle_instanced_arrays')
     }


### PR DESCRIPTION
   Fix so that the 'instancing' extension is not only injected for 'draw'
    calls, but also for the other types.