### PR TITLE
Cube map and render buffer add properties

### DIFF
--- a/API.md
+++ b/API.md
@@ -110,7 +110,7 @@
         -   [Renderbuffer update](#renderbuffer-update)
 
             -   [Renderbuffer resize](#renderbuffer-resize)
-        -   [Renderbuffer properties](#renderbufffer-properties)
+        -   [Renderbuffer properties](#renderbuffer-properties)
 
         -   [Renderbuffers destructor](#renderbuffers-destructor)
 
@@ -2120,9 +2120,9 @@ var renderbuffer = regl.renderbuffer({
 renderbuffer.resize(32, 32)
 ```
 
-#### Renderbufffer properties
+#### Renderbuffer properties
 
-The following properties contains information about the cube map.
+The following properties contains information about the renderbuffer.
 
 | Property           | Description                      |
 | ------------------ | -------------------------------- |

--- a/API.md
+++ b/API.md
@@ -110,7 +110,7 @@
         -   [Renderbuffer update](#renderbuffer-update)
 
             -   [Renderbuffer resize](#renderbuffer-resize)
-        -   [Renderbuffer properties](#renderbuffer-properties)
+        -   [Renderbuffer properties](#renderbufffer-properties)
 
         -   [Renderbuffers destructor](#renderbuffers-destructor)
 

--- a/API.md
+++ b/API.md
@@ -2002,6 +2002,32 @@ var cubemap = regl.cube({ ... })
 cubemap.resize(16)
 ```
 
+#### Cube map properties
+
+The following properties contains information about the cube map.
+
+| Property           | Description                      |
+| ------------------ | -------------------------------- |
+| `width`            | Width of a single cube map face                 |
+| `height`           | Height of a single cube map face                |
+| `format`           | Texture Format                   |
+| `type`             | Texture Type                     |
+| `mag`              | Texture magnification filter     |
+| `min`              | Texture minification filter      |
+| `wrapS`            | Texture wrap mode on S axis      |
+| `wrapT`            | Texture wrap mode on T axis      |
+
+They can be accessed after cube map creation like this:
+
+```javascript
+var c = regl.cube({
+  width: 2,
+  height: 2
+})
+
+console.log('cube: ', c.width, c.height, c.format, c.type, c.mag, c.min, c.wrapS, c.wrapT)
+```
+
 #### Cube map profiling
 
 The following stats are tracked for each cube map in the `.stats` property:
@@ -2090,6 +2116,26 @@ var renderbuffer = regl.renderbuffer({
 })
 
 renderbuffer.resize(32, 32)
+```
+
+#### Renderbufffer properties
+
+The following properties contains information about the cube map.
+
+| Property           | Description                      |
+| ------------------ | -------------------------------- |
+| `width`            | Width of the renderbuffer                 |
+| `height`           | Height of the renderbuffer                 |
+| `format`           | Format of the renderbuffer                   |
+
+They can be accessed after renderbuffer creation like this:
+
+```javascript
+var r = regl.renderbuffer({shape: [1, 1],
+  format: 'rgb5 a1'
+})
+
+console.log('renderbuffer: ', r.width, r.height, r.format)
 ```
 
 #### Renderbuffers destructor

--- a/API.md
+++ b/API.md
@@ -97,6 +97,7 @@
             -   [Cube map subimage](#cube-map-subimage)
 
         -   [Cube map resize](#cube-map-resize)
+        -   [Cube map properties](#cube-map-properties)
 
         -   [Cube map profiling](#cube-map-profiling)
 
@@ -109,6 +110,7 @@
         -   [Renderbuffer update](#renderbuffer-update)
 
             -   [Renderbuffer resize](#renderbuffer-resize)
+        -   [Renderbuffer properties](#renderbuffer-properties)
 
         -   [Renderbuffers destructor](#renderbuffers-destructor)
 

--- a/lib/renderbuffer.js
+++ b/lib/renderbuffer.js
@@ -59,6 +59,12 @@ module.exports = function (gl, extensions, limits, stats, config) {
     formatTypes['rgba32f'] = GL_RGBA32F_EXT
   }
 
+  var formatTypesInvert = []
+  Object.keys(formatTypes).forEach(function (key) {
+    var val = formatTypes[key]
+    formatTypesInvert[val] = key
+  })
+
   var renderbufferCount = 0
   var renderbufferSet = {}
 
@@ -163,6 +169,7 @@ module.exports = function (gl, extensions, limits, stats, config) {
       if (config.profile) {
         renderbuffer.stats.size = getRenderbufferSize(renderbuffer.format, renderbuffer.width, renderbuffer.height)
       }
+      reglRenderbuffer.format = formatTypesInvert[renderbuffer.format]
 
       return reglRenderbuffer
     }

--- a/lib/texture.js
+++ b/lib/texture.js
@@ -1459,6 +1459,15 @@ module.exports = function createTextureSet (
           true)
       }
 
+      reglTextureCube.format = textureFormatsInvert[texture.internalformat]
+      reglTextureCube.type = textureTypesInvert[texture.type]
+
+      reglTextureCube.mag = magFiltersInvert[texInfo.magFilter]
+      reglTextureCube.min = minFiltersInvert[texInfo.minFilter]
+
+      reglTextureCube.wrapS = wrapModesInvert[texInfo.wrapS]
+      reglTextureCube.wrapT = wrapModesInvert[texInfo.wrapT]
+
       for (i = 0; i < 6; ++i) {
         freeMipMap(faces[i])
       }

--- a/test/renderbuffer.js
+++ b/test/renderbuffer.js
@@ -181,6 +181,33 @@ tape('renderbuffer parsing', function (t) {
     })
   }
 
+  function checkFormat (args) {
+    args.shape = [1, 1]
+    var r = regl.renderbuffer(args)
+    var expectedFormat = args.format
+    t.equals(r.format, expectedFormat, ' format str for format ' + expectedFormat)
+  }
+
+  checkFormat({format: 'rgba4'})
+  checkFormat({format: 'rgb565'})
+  checkFormat({format: 'rgb5 a1'})
+  checkFormat({format: 'depth'})
+  checkFormat({format: 'stencil'})
+  checkFormat({format: 'depth stencil'})
+
+  if (regl.hasExtension('ext_srgb')) {
+    checkFormat({format: 'srgba'})
+  }
+
+  if (regl.hasExtension('webgl_color_buffer_float')) {
+    checkFormat({format: 'rgba32f'})
+  }
+
+  if (regl.hasExtension('ext_color_buffer_half_float')) {
+    checkFormat({format: 'rgba16f'})
+    checkFormat({format: 'rgb16f'})
+  }
+
   regl.destroy()
   t.equals(gl.getError(), 0, 'error ok')
   createContext.destroy(gl)

--- a/test/textureCube.js
+++ b/test/textureCube.js
@@ -6,7 +6,12 @@ tape('texture cube', function (t) {
   var gl = createContext(16, 16)
   var regl = createREGL({
     gl: gl,
-    optionalExtensions: ['ext_texture_filter_anisotropic']
+    optionalExtensions: [
+      'ext_texture_filter_anisotropic',
+      'oes_texture_float',
+      'oes_texture_half_float',
+      'ext_srgb'
+    ]
   })
 
   var renderCubeFace = regl({
@@ -106,6 +111,15 @@ tape('texture cube', function (t) {
 
     t.equals(texture.width, width, name + ' width')
     t.equals(texture.height, height, name + ' height')
+
+    t.equals(texture.format, props.format || 'rgba', name + ': format')
+    t.equals(texture.type, props.type || 'uint8', name + ': type')
+
+    t.equals(texture.mag, props.mag || 'nearest', name + ': mag filter')
+    t.equals(texture.min, props.min || 'nearest', name + ': min filter')
+
+    t.equals(texture.wrapS, props.wrapS || 'clamp', name + ': wrapS')
+    t.equals(texture.wrapT, props.wrapT || 'clamp', name + ': wrapT')
 
     if ('faces' in props) {
       comparePixels(texture, width, height, props.faces, props.tolerance || 0,
@@ -354,6 +368,48 @@ tape('texture cube', function (t) {
         0, 0, 0, 0, 0, 0, 0, 0
       ]
     ]
+  })
+
+  // in the below tests, we make sure that we can properly read the properties
+  // 'format', 'type', 'min', 'mag', 'wrapS, 'wrapT' from the created texture.
+
+  var testCases = [
+    {format: 'rgba', type: 'uint8'},
+    {format: 'rgba4', type: 'rgba4'},
+    {format: 'rgb565', type: 'rgb565'},
+    {format: 'rgb5 a1', type: 'rgb5 a1'},
+    {format: 'alpha', type: 'uint8'},
+    {format: 'luminance', type: 'uint8'},
+    {format: 'luminance alpha', type: 'uint8'}
+  ]
+
+  if (regl.hasExtension('oes_texture_float')) {
+    testCases.push({format: 'rgba', type: 'float32'})
+    testCases.push({format: 'rgb', type: 'float32'})
+    testCases.push({format: 'luminance', type: 'float32'})
+    testCases.push({format: 'luminance alpha', type: 'float32'})
+  }
+
+  if (regl.hasExtension('oes_texture_half_float')) {
+    testCases.push({format: 'rgba', type: 'float16'})
+    testCases.push({format: 'luminance', type: 'float16'})
+    testCases.push({format: 'luminance alpha', type: 'float16'})
+  }
+
+  if (regl.hasExtension('ext_srgb')) {
+    testCases.push({format: 'srgba', type: 'uint8'})
+    testCases.push({format: 'srgb', type: 'uint8'})
+  }
+
+  // TODO: also add compressed formats to 'testCases'
+
+  testCases.forEach(function (testCase, i) {
+    var name = 'for format = ' + testCase.format + ' and type = ' + testCase.type
+
+    var arg = testCase
+    arg.width = 1
+    arg.height = 1
+    checkProperties(name, regl.cube(arg), testCase)
   })
 
   // TODO mipmaps

--- a/test/textureCube.js
+++ b/test/textureCube.js
@@ -400,11 +400,27 @@ tape('texture cube', function (t) {
     testCases.push({format: 'srgba', type: 'uint8'})
     testCases.push({format: 'srgb', type: 'uint8'})
   }
-
   // TODO: also add compressed formats to 'testCases'
 
+  testCases.push({mag: 'nearest', min: 'nearest'})
+  testCases.push({mag: 'linear', min: 'linear'})
+  testCases.push({mag: 'linear', min: 'linear mipmap linear'})
+  testCases.push({mag: 'linear', min: 'nearest mipmap linear'})
+  testCases.push({mag: 'linear', min: 'linear mipmap nearest'})
+  testCases.push({mag: 'linear', min: 'nearest mipmap nearest'})
+
+  testCases.push({wrapS: 'clamp', wrapT: 'clamp'})
+
   testCases.forEach(function (testCase, i) {
-    var name = 'for format = ' + testCase.format + ' and type = ' + testCase.type
+    var name
+
+    if (testCase.format) { // case for 'format' and 'type'.
+      name = 'for format = ' + testCase.format + ' and type = ' + testCase.type
+    } else if (testCase.mag) { // case for 'mag' and 'min'
+      name = 'for mag = ' + testCase.mag + ' and min = ' + testCase.min
+    } else { // case for 'wrapS' and 'wrapT'
+      name = 'for wrapS = ' + testCase.wrapS + ' and wrapT = ' + testCase.wrapT
+    }
 
     var arg = testCase
     arg.width = 1


### PR DESCRIPTION
You can now query these properties of a cube map after creation: width, height, format, type, mag, min, wrapS, wrapT. Like this:

```javascript
var c = regl.cube({
  width: 2,
  height: 2
})

console.log('cube: ', c.width, c.height, c.format, c.type, c.mag, c.min, c.wrapS, c.wrapT)
```

you can now also query the 'format' of a renderbuffer after creation:

```javascript
var r = regl.renderbuffer({shape: [1, 1],
  format: 'rgb5 a1'
})

console.log('renderbuffer: ', r.width, r.height, r.format)

```