### PR TITLE
Fix typo in API docs (comma vs colon)

### DIFF
--- a/API.md
+++ b/API.md
@@ -634,7 +634,7 @@ var command = regl({
   uniforms: {
     someUniform: [1, 0, 0, 1],
     anotherUniform: regl.prop('myProp'),
-    'nested.value', 5.3
+    'nested.value': 5.3
   },
 
   // ...


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mikolalysenko/regl/302)
<!-- Reviewable:end -->
